### PR TITLE
Make include homogenous between id and collection

### DIFF
--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
@@ -21,14 +21,14 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSelector<T>, ElideNavigatorOnId<T>, ElideNavigatorOnCollection<T> {
-  private Optional<String> id = Optional.empty();
   @Getter
-  private Class<T> dtoClass;
-  private Optional<ElideNavigator<?>> parentNavigator;
+  private final Class<T> dtoClass;
+  private final List<String> includes = new ArrayList<>();
+  private final List<String> sorts = new ArrayList<>();
+  private final Optional<ElideNavigator<?>> parentNavigator;
   private String parentName = null;
+  private Optional<String> id = Optional.empty();
   private Optional<String> relationship = Optional.empty();
-  private List<String> includes = new ArrayList<>();
-  private List<String> sorts = new ArrayList<>();
   private Optional<Condition<?>> filterCondition = Optional.empty();
   private Optional<Integer> pageSize = Optional.empty();
   private Optional<Integer> pageNumber = Optional.empty();
@@ -92,15 +92,11 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
   }
 
   /**
-   * Add an include to an ID-pointed ElideNavigator
+   * Add an include to an ElideNavigator
    * Important: ElideNavigator takes care of referencing to the correct parent relationships. Just use a relative include.
    */
   @Override
-  public ElideNavigatorOnId<T> addIncludeOnId(@NotNull String include) {
-    return addInclude(include);
-  }
-
-  private ElideNavigator<T> addInclude(@NotNull String include) {
+  public ElideNavigator<T> addInclude(@NotNull String include) {
     log.trace("include added: {}", include);
     includes.add(include);
     return this;
@@ -111,15 +107,6 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
     log.trace("relationship added: {}", name);
     this.relationship = Optional.of(name);
     return new ElideNavigator<>(dtoClass, this, name);
-  }
-
-  /**
-   * Add an include to a collection-pointed ElideNavigator
-   * Important: ElideNavigator takes care of referencing to the correct parent relationships. Just use a relative include.
-   */
-  @Override
-  public ElideNavigatorOnCollection<T> addIncludeOnCollection(@NotNull String include) {
-    return addInclude(include);
   }
 
   /**

--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnCollection.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnCollection.java
@@ -4,7 +4,7 @@ import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 
 public interface ElideNavigatorOnCollection<T extends ElideEntity> {
 
-  ElideNavigatorOnCollection<T> addIncludeOnCollection(String include);
+  ElideNavigatorOnCollection<T> addInclude(String include);
 
   ElideNavigatorOnCollection<T> addSortingRule(String field, boolean ascending);
 

--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
@@ -2,7 +2,7 @@ package com.faforever.commons.api.elide;
 
 public interface ElideNavigatorOnId<T extends ElideEntity> {
 
-  ElideNavigatorOnId<T> addIncludeOnId(String include);
+  ElideNavigatorOnId<T> addInclude(String include);
 
   <R extends ElideEntity> ElideNavigatorSelector<R> navigateRelationship(Class<R> entityClass, String name);
 

--- a/faf-commons-api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
+++ b/faf-commons-api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
@@ -27,7 +27,7 @@ class ElideNavigatorTest {
   void testGetListSingleInclude() {
     assertThat(ElideNavigator.of(Ladder1v1Map.class)
       .collection()
-      .addIncludeOnCollection("mapVersion")
+      .addInclude("mapVersion")
       .build(), is("/data/ladder1v1Map?include=mapVersion"));
   }
 
@@ -35,8 +35,8 @@ class ElideNavigatorTest {
   void testGetListMultipleInclude() {
     assertThat(ElideNavigator.of(Ladder1v1Map.class)
       .collection()
-      .addIncludeOnCollection("mapVersion")
-      .addIncludeOnCollection("mapVersion.map")
+      .addInclude("mapVersion")
+      .addInclude("mapVersion.map")
       .build(), is("/data/ladder1v1Map?include=mapVersion,mapVersion.map"));
   }
 
@@ -57,8 +57,8 @@ class ElideNavigatorTest {
   void testGetListCombinedFilter() {
     assertThat(ElideNavigator.of(Ladder1v1Map.class)
       .collection()
-      .addIncludeOnCollection("mapVersion")
-      .addIncludeOnCollection("mapVersion.map")
+      .addInclude("mapVersion")
+      .addInclude("mapVersion.map")
       .pageSize(10)
       .pageNumber(3)
       .addFilter(
@@ -74,8 +74,8 @@ class ElideNavigatorTest {
   void testGetIdMultipleInclude() {
     assertThat(ElideNavigator.of(Ladder1v1Map.class)
       .id("5")
-      .addIncludeOnId("mapVersion")
-      .addIncludeOnId("mapVersion.map")
+      .addInclude("mapVersion")
+      .addInclude("mapVersion.map")
       .build(), is("/data/ladder1v1Map/5?include=mapVersion,mapVersion.map"));
   }
 


### PR DESCRIPTION
This simplifies includes so that theoretically a method could enrich a navigator with include for both id and collection navigators