### PR TITLE
Introduce ElideEndpointBuilder 

### DIFF
--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideEndpointBuilder.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideEndpointBuilder.java
@@ -1,0 +1,9 @@
+package com.faforever.commons.api.elide;
+
+public interface ElideEndpointBuilder<T extends ElideEntity> {
+  String build();
+
+  Class<T> getDtoClass();
+
+  ElideEndpointBuilder<T> addInclude(String include);
+}

--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
@@ -126,10 +126,15 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
    * Important: ElideNavigator takes care of referencing to the correct parent relationships. Just use a relative include.
    */
   @Override
-  public ElideNavigatorOnCollection<T> addFilter(@NotNull Condition<?> eq) {
+  public ElideNavigatorOnCollection<T> setFilter(@NotNull Condition<?> eq) {
     log.trace("filter set: {}", eq);
     filterCondition = Optional.of(eq);
     return this;
+  }
+
+  @Override
+  public Optional<Condition<?>> getFilter() {
+    return filterCondition;
   }
 
   @Override

--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnCollection.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnCollection.java
@@ -2,21 +2,21 @@ package com.faforever.commons.api.elide;
 
 import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 
-public interface ElideNavigatorOnCollection<T extends ElideEntity> {
+import java.util.Optional;
+
+public interface ElideNavigatorOnCollection<T extends ElideEntity> extends ElideEndpointBuilder<T>{
 
   ElideNavigatorOnCollection<T> addInclude(String include);
 
   ElideNavigatorOnCollection<T> addSortingRule(String field, boolean ascending);
 
-  ElideNavigatorOnCollection<T> addFilter(Condition<?> eq);
+  Optional<Condition<?>> getFilter();
+
+  ElideNavigatorOnCollection<T> setFilter(Condition<?> eq);
 
   ElideNavigatorOnCollection<T> pageSize(int size);
 
   ElideNavigatorOnCollection<T> pageNumber(int number);
 
   ElideNavigatorOnCollection<T> pageTotals(boolean showTotals);
-
-  Class<T> getDtoClass();
-
-  String build();
 }

--- a/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
+++ b/faf-commons-api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
@@ -1,12 +1,9 @@
 package com.faforever.commons.api.elide;
 
-public interface ElideNavigatorOnId<T extends ElideEntity> {
+public interface ElideNavigatorOnId<T extends ElideEntity> extends ElideEndpointBuilder<T>{
 
   ElideNavigatorOnId<T> addInclude(String include);
 
   <R extends ElideEntity> ElideNavigatorSelector<R> navigateRelationship(Class<R> entityClass, String name);
 
-  Class<T> getDtoClass();
-
-  String build();
 }

--- a/faf-commons-api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
+++ b/faf-commons-api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
@@ -3,9 +3,12 @@ package com.faforever.commons.api.elide;
 import com.faforever.commons.api.dto.Ladder1v1Map;
 import com.faforever.commons.api.dto.MapPoolAssignment;
 import com.faforever.commons.api.dto.MapVersion;
+import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 import org.junit.jupiter.api.Test;
 
+import static com.faforever.commons.api.elide.ElideNavigator.qBuilder;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class ElideNavigatorTest {
@@ -44,8 +47,8 @@ class ElideNavigatorTest {
   void testGetListFiltered() {
     assertThat(ElideNavigator.of(Ladder1v1Map.class)
       .collection()
-      .addFilter(
-        ElideNavigator.qBuilder()
+      .setFilter(
+        qBuilder()
           .intNum("mapVersion.id").gt(10)
           .or()
           .string("hello").eq("nana")
@@ -61,8 +64,8 @@ class ElideNavigatorTest {
       .addInclude("mapVersion.map")
       .pageSize(10)
       .pageNumber(3)
-      .addFilter(
-        ElideNavigator.qBuilder()
+      .setFilter(
+        qBuilder()
           .intNum("mapVersion.id").gt(10)
           .or()
           .string("hello").eq("nana")
@@ -105,6 +108,16 @@ class ElideNavigatorTest {
       .pageNumber(1)
       .pageTotals(true)
       .build(), is("/data/mapPoolAssignment?page[size]=1&page[number]=1&page[totals]"));
+  }
+
+  @Test
+  void testGetFilter() {
+    ElideNavigatorOnCollection<MapPoolAssignment> navigator = ElideNavigator.of(MapPoolAssignment.class)
+      .collection();
+    assertThat(navigator.getFilter().isEmpty(), is(true));
+    Condition<?> condition = qBuilder().string("test").eq("test");
+    navigator.setFilter(condition);
+    assertThat(navigator.getFilter().get(), is(condition));
   }
 
 }


### PR DESCRIPTION
Creates a single interface that can be used for building an endpoint from an id or a collection navigator