### PR TITLE
Refactor 'parseModeratorEvent' to Use 'player' as 'activeCommandSource' (#125)

### DIFF
--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -279,7 +279,7 @@ public class ReplayDataParser {
             }
 
             if (Objects.equals("ModeratorEvent", functionName)) {
-              parseModeratorEvent((Map<String, Object>) lua);
+              parseModeratorEvent((Map<String, Object>) lua, player);
             }
 
             // No idea what this skips
@@ -378,13 +378,10 @@ public class ReplayDataParser {
   }
 
 
-  void parseModeratorEvent(Map<String, Object> lua) {
+  void parseModeratorEvent(Map<String, Object> lua, Integer player) {
     String messageContent = (String) lua.get("Message");
     int fromInt = ((Number) lua.get("From")).intValue();
-    int activeCommandSource = 0; // activeCommandSource is not available in .fafreplay, yet
-    if (lua.containsKey("activeCommandSource")) {
-      activeCommandSource = ((Number) lua.get("activeCommandSource")).intValue();
-    }
+    int activeCommandSource = player;
     moderatorEvents.add(new ModeratorEvent(tickToTime(ticks), Integer.toString(fromInt), messageContent, activeCommandSource));
   }
 


### PR DESCRIPTION
This PR addresses issue #125 by refactoring 'parseModeratorEvent' to accept 'player' as 'activeCommandSource' and update function calls

My steps:

1. Removing (my previous) unnecessary code related to assignment of 'activeCommandSource'
2. Assign the int value of 'player' to 'activeCommandSource'
3. Added a second parameter Integer 'player' to the 'ParseModeratorEvent'


Fixes #125 

Thanks, @Garanas for the detailed task issue and examples.
Thanks in advance for your code review @Brutus5000 or @Sheikah45