### PR TITLE
Enhanced robustness of method parseModeratorEvent (#124)

### DIFF
--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -383,11 +383,11 @@ public class ReplayDataParser {
     int fromInt = -1; // Default Value
     int activeCommandSource = -1; // Default Value
 
-    if (lua.containsKey("Message") && lua.get("Message") instanceof String) {
-      messageContent = (String) lua.get("Message");
+    if (lua.containsKey("Message") && lua.get("Message") instanceof String value) {
+      messageContent = value;
     }
-    if (lua.containsKey("From") && lua.get("From") instanceof Number) {
-      fromInt = ((Number) lua.get("From")).intValue();
+    if (lua.containsKey("From") && lua.get("From") instanceof Number value) {
+      fromInt = value.intValue();
     }
     if (player != null) {
       activeCommandSource = player;

--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -379,12 +379,22 @@ public class ReplayDataParser {
 
 
   void parseModeratorEvent(Map<String, Object> lua, Integer player) {
-    String messageContent = (String) lua.get("Message");
-    int fromInt = ((Number) lua.get("From")).intValue();
-    int activeCommandSource = player;
+    String messageContent = "Content of Message Missing";
+    int fromInt = -1; // Default Value
+    int activeCommandSource = -1; // Default Value
+
+    if (lua.containsKey("Message") && lua.get("Message") instanceof String) {
+      messageContent = (String) lua.get("Message");
+    }
+    if (lua.containsKey("From") && lua.get("From") instanceof Number) {
+      fromInt = ((Number) lua.get("From")).intValue();
+    }
+    if (player != null) {
+      activeCommandSource = player;
+    }
+
     moderatorEvents.add(new ModeratorEvent(tickToTime(ticks), Integer.toString(fromInt), messageContent, activeCommandSource));
   }
-
 
   private Duration tickToTime(int tick) {
     return Duration.ofSeconds(tick / 10);


### PR DESCRIPTION
This PR addresses issue #124 by adding default values to `parseModeratorEvent`to handle any malformed data. 

Outlined Steps:

1. Assign default values to `messageContent`, `fromInt`, and `activeCommandSource`
2. Check if `Message` and `From` exist in lua using `containsKey` and `get`
3. Null check for parameter `player` before assignment to `activeCommandSource`

Fixes #124

Thanks, @Garanas for the detailed task issue and mentioned example.
Thanks in advance for your code review @Brutus5000 or @Sheikah45
 