### PR TITLE
Feature/#125 enhance parse moderator event to include player names

### DIFF
--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ModeratorEvent.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ModeratorEvent.java
@@ -2,6 +2,10 @@ package com.faforever.commons.replay;
 
 import java.time.Duration;
 
-public record ModeratorEvent(Duration time, String sender, String message, int activeCommandSource) {
-
+public record ModeratorEvent(Duration time,
+                             int activeCommandSource,
+                             int fromArmy,
+                             String message,
+                             String playerNameFromArmy,
+                             String playerNameFromCommandSource) {
 }

--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -380,20 +380,35 @@ public class ReplayDataParser {
 
   void parseModeratorEvent(Map<String, Object> lua, Integer player) {
     String messageContent = "Content of Message Missing";
-    int fromInt = -1; // Default Value
+    String playerNameFromArmy = "Player Name Army Missing";
+    String playerNameFromCommandSource = "Player Name Command Source Missing";
     int activeCommandSource = -1; // Default Value
+    int fromArmy = -1; // Default Value
 
     if (lua.containsKey("Message") && lua.get("Message") instanceof String value) {
       messageContent = value;
     }
+
     if (lua.containsKey("From") && lua.get("From") instanceof Number value) {
-      fromInt = value.intValue();
-    }
-    if (player != null) {
-      activeCommandSource = player;
+      fromArmy = value.intValue() - 1;
+
+      if (fromArmy != -2) {
+        Map<String, Object> army = armies.get(fromArmy);
+
+        if (army != null){
+          playerNameFromArmy = (String) army.get("PlayerName");
+        }
+      }
     }
 
-    moderatorEvents.add(new ModeratorEvent(tickToTime(ticks), Integer.toString(fromInt), messageContent, activeCommandSource));
+    if (player != null) {
+      activeCommandSource = player;
+      Map<String, Object> army = armies.get(activeCommandSource);
+      playerNameFromCommandSource = (String) army.get("PlayerName");
+    }
+
+    moderatorEvents.add(new ModeratorEvent(tickToTime(ticks), activeCommandSource, fromArmy,
+      messageContent, playerNameFromArmy, playerNameFromCommandSource));
   }
 
   private Duration tickToTime(int tick) {

--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -382,8 +382,8 @@ public class ReplayDataParser {
     String messageContent = null;
     String playerNameFromArmy = null;
     String playerNameFromCommandSource = null;
-    int activeCommandSource = -2; // Default Value
-    int fromArmy = -2; // Default Value
+    Integer activeCommandSource = null;
+    Integer fromArmy = null;
 
     if (lua.containsKey("Message") && lua.get("Message") instanceof String value) {
       messageContent = value;
@@ -404,7 +404,10 @@ public class ReplayDataParser {
     if (player != null) {
       activeCommandSource = player;
       Map<String, Object> army = armies.get(activeCommandSource);
-      playerNameFromCommandSource = (String) army.get("PlayerName");
+
+      if (army != null) {
+        playerNameFromCommandSource = (String) army.get("PlayerName");
+      }
     }
 
     moderatorEvents.add(new ModeratorEvent(tickToTime(ticks), activeCommandSource, fromArmy,

--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -382,8 +382,8 @@ public class ReplayDataParser {
     String messageContent = null;
     String playerNameFromArmy = null;
     String playerNameFromCommandSource = null;
-    int activeCommandSource = -1; // Default Value
-    int fromArmy = -1; // Default Value
+    int activeCommandSource = -2; // Default Value
+    int fromArmy = -2; // Default Value
 
     if (lua.containsKey("Message") && lua.get("Message") instanceof String value) {
       messageContent = value;

--- a/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/faf-commons-data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -379,9 +379,9 @@ public class ReplayDataParser {
 
 
   void parseModeratorEvent(Map<String, Object> lua, Integer player) {
-    String messageContent = "Content of Message Missing";
-    String playerNameFromArmy = "Player Name Army Missing";
-    String playerNameFromCommandSource = "Player Name Command Source Missing";
+    String messageContent = null;
+    String playerNameFromArmy = null;
+    String playerNameFromCommandSource = null;
     int activeCommandSource = -1; // Default Value
     int fromArmy = -1; // Default Value
 


### PR DESCRIPTION
This PR addresses issue #133 by adding the player name to the moderator parser

Outlined Steps:

1. Renamed `fromInt` to `fromArmy` to align with the naming convention used in method `parseGiveResourcesToPlayer`. This makes it more readable when working with the `armies` object.
2. Set default values for `playerNameFromArmy` and `playerNameFromCommandSource`.
3. Retrieved `playerNameFromArmy` from the `armies` object (similar to `parseGiveResourcesToPlayer`).
4. Retrieved `playerNameFromCommandSource` via `activeCommandSource` from the `armies` object.


This allows us to access the player names in Mordor like in the following image (I locally imported the faf-java-commons into Mordor and tested the output):




<details>
  <summary>Click to reveal images about the output</summary>

![image](https://github.com/FAForever/faf-java-commons/assets/101107758/b5be250c-e954-4775-b3e8-acaa4af4ad69)


![image](https://github.com/FAForever/faf-java-commons/assets/101107758/deba5883-085e-483f-af48-adcdbf6a9984)

</details>



@Garanas, the next step would be to bring those events officially to Mordor as seen in the image - I will raise an issue there later/tomorrow. Code is already in the pipeline.

Thanks in advance for your code review @Brutus5000, @Garanas, @Sheikah45

Fixes #133 










