### PR TITLE
fix(request-join-game): Handle game_join_failed command properly

### DIFF
--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/ConnectionApi.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/ConnectionApi.kt
@@ -54,6 +54,15 @@ data class NoticeInfo(
   val text: String?,
 ) : ServerMessage
 
+/**
+ * Error response from server when joining a game.
+ */
+data class GameJoinFailed (
+  @JsonProperty("uid")
+  val gameId: Int,
+  @JsonProperty("reason")
+  val reason: String?,
+) : ServerMessage
 
 /**
  * The server assigns us a session id, onto which we will authorize.

--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyApi.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyApi.kt
@@ -67,6 +67,7 @@ interface ClientMessage : LobbyProtocolMessage
   JsonSubTypes.Type(value = SocialInfo::class, name = "social"),
   JsonSubTypes.Type(value = LoginFailedResponse::class, name = "authentication_failed"),
   JsonSubTypes.Type(value = NoticeInfo::class, name = "notice"),
+  JsonSubTypes.Type(value = GameJoinFailed::class, name = "game_join_failed"),
   JsonSubTypes.Type(value = IceServerListResponse::class, name = "ice_servers"),
   JsonSubTypes.Type(value = AvatarListInfo::class, name = "avatar"),
   JsonSubTypes.Type(value = PartyInfo::class, name = "update_party"),

--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyClient.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyClient.kt
@@ -286,14 +286,23 @@ class FafLobbyClient(
         .next()
     )
 
-  override fun requestJoinGame(gameId: Int, password: String?): Mono<GameLaunchResponse> =
-    Mono.fromCallable {
-      send(JoinGameRequest(gameId, password))
-    }.then(
-      events
-        .ofType(GameLaunchResponse::class.java)
-        .next()
-    )
+  override fun requestJoinGame(gameId: Int, password: String?): Mono<GameLaunchResponse> {
+    return Mono.fromCallable { send(JoinGameRequest(gameId, password)) }
+      .then(
+        events.filter { event ->
+          (event is GameJoinFailed && gameId == event.gameId) || (event is GameLaunchResponse && gameId == event.uid)
+        }
+          .flatMap { event ->
+            when (event) {
+              is GameJoinFailed -> Mono.error(GameJoinFailedException(gameId))
+              is GameLaunchResponse -> Mono.just(event)
+              else -> Mono.empty()
+            }
+          }
+          .next()
+      )
+  }
+
 
   override fun restoreGameSession(gameId: Int) = send(RestoreGameSessionRequest(gameId))
 

--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyClient.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/FafLobbyClient.kt
@@ -294,7 +294,7 @@ class FafLobbyClient(
         }
           .flatMap { event ->
             when (event) {
-              is GameJoinFailed -> Mono.error(GameJoinFailedException(gameId))
+              is GameJoinFailed -> Mono.error(GameJoinFailedException(gameId, event.reason))
               is GameLaunchResponse -> Mono.just(event)
               else -> Mono.empty()
             }

--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/GameApi.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/GameApi.kt
@@ -22,6 +22,9 @@ interface GameApi {
     enforceRatingRange: Boolean
   ): Mono<GameLaunchResponse>
 
+  /**
+   * Mono can fail with GameJoinFailedException if the joining of the game fails
+   */
   fun requestJoinGame(gameId: Int, password: String?): Mono<GameLaunchResponse>
 
   fun restoreGameSession(gameId: Int)

--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/GameJoinFailedException.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/GameJoinFailedException.kt
@@ -1,0 +1,7 @@
+package com.faforever.commons.lobby
+
+class GameJoinFailedException(private val gameId: Int) : RuntimeException("Failed to join game with id: $gameId") {
+  fun getGameId(): Int {
+    return gameId
+  }
+}

--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/GameJoinFailedException.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/GameJoinFailedException.kt
@@ -1,7 +1,6 @@
 package com.faforever.commons.lobby
 
-class GameJoinFailedException(private val gameId: Int) : RuntimeException("Failed to join game with id: $gameId") {
-  fun getGameId(): Int {
-    return gameId
-  }
-}
+class GameJoinFailedException(
+  val gameId: Int,
+  val failureReason: String?
+) : RuntimeException()

--- a/lobby/src/test/kotlin/com/faforever/commons/lobby/LobbyClientTest.kt
+++ b/lobby/src/test/kotlin/com/faforever/commons/lobby/LobbyClientTest.kt
@@ -189,6 +189,24 @@ class LobbyClientTest {
   }
 
   @Test
+  fun testJoinGameFailed() {
+    val gameId = 789
+    val password = "testPassword"
+
+    val joinFailedEvent = GameJoinFailed(gameId, null)
+    serverMessagesReceived.filter { commandMatches(it, "game_join") }
+      .next()
+      .doOnNext {
+        sendFromServer(joinFailedEvent)
+      }
+      .subscribe()
+
+    StepVerifier.create(instance.requestJoinGame(gameId, password))
+      .expectError(GameJoinFailedException::class.java)
+      .verify(verificationDuration)
+  }
+
+  @Test
   fun testRestoreGameSession() {
     val stepVerifier = StepVerifier.create(serverMessagesReceived.take(1)).assertNext { assertCommandMatch(it, RestoreGameSessionRequest(0)) }.expectComplete().verifyLater()
 

--- a/lobby/src/test/kotlin/com/faforever/commons/lobby/ServerMessageTest.kt
+++ b/lobby/src/test/kotlin/com/faforever/commons/lobby/ServerMessageTest.kt
@@ -102,6 +102,16 @@ class ServerMessageTest {
   }
 
   @Test
+  fun deserializeGameJoinFailed() {
+    val result = objectMapper.readValue<ServerMessage>(
+      """
+      {"command":"game_join_failed","reason":"badpass", "uid": "1232"}
+    """.trimIndent()
+    )
+    assertEquals(GameJoinFailed(1232, "badpass"), result)
+  }
+
+  @Test
   fun deserializeSessionResponse() {
     val result = objectMapper.readValue<ServerMessage>(
       """


### PR DESCRIPTION
Ensure Mono ends exceptionally when a negative game join occurs

Closes #209
