### PR TITLE
Replay parsing performance improvements

### DIFF
--- a/data/src/main/java/com/faforever/commons/replay/QtCompress.java
+++ b/data/src/main/java/com/faforever/commons/replay/QtCompress.java
@@ -3,11 +3,8 @@ package com.faforever.commons.replay;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.Inflater;
-import java.util.zip.InflaterOutputStream;
+import java.nio.ByteBuffer;
+import java.util.zip.*;
 
 /**
  * Utility class that compresses and uncompresses bytes like QT's <a href="http://doc.qt.io/qt-5/qbytearray.html">QByteArray</a>.
@@ -22,17 +19,19 @@ public final class QtCompress {
    * Compresses the specified bytes like <a href="http://doc.qt.io/qt-5/qbytearray.html#qCompress">QByteArray.qCompress()</a>
    * does.
    */
-  public static byte[] qUncompress(byte[] bytes) throws IOException {
+  public static ByteBuffer qUncompress(ByteBuffer inputBuffer) {
     Inflater inflater = new Inflater();
-    inflater.setInput(Arrays.copyOfRange(bytes, 4, bytes.length));
+    final int uncompressedLength = inputBuffer.getInt();
+    inflater.setInput(inputBuffer);
+    final var outputBytes = new byte[uncompressedLength];
 
-    ByteArrayOutputStream byteArray = new ByteArrayOutputStream();
-
-    try (InflaterOutputStream inflaterOutputStream = new InflaterOutputStream(byteArray, inflater)) {
-      inflaterOutputStream.flush();
+    try {
+      inflater.inflate(outputBytes);
+    } catch (DataFormatException e) {
+      throw new RuntimeException(e);
     }
 
-    return byteArray.toByteArray();
+    return ByteBuffer.wrap(outputBytes);
   }
 
   /**

--- a/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -4,30 +4,30 @@ import com.faforever.commons.replay.body.Event;
 import com.faforever.commons.replay.body.ReplayBodyParser;
 import com.faforever.commons.replay.body.ReplayBodyToken;
 import com.faforever.commons.replay.body.ReplayBodyTokenizer;
+import com.faforever.commons.replay.shared.LoadUtils;
 import com.faforever.commons.replay.shared.LuaData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.LittleEndianDataInputStream;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 
 @SuppressWarnings("unused")
 @Slf4j
@@ -59,7 +59,7 @@ public class ReplayDataParser {
   @Getter
   private final List<ModeratorEvent> moderatorEvents = new ArrayList<>();
   @Getter
-  private final Map<Integer, Map<Integer, AtomicInteger>> commandsPerMinuteByPlayer = new HashMap<>();
+  private Map<String, Integer> playerIdsByName;
 
   private int ticks;
 
@@ -80,48 +80,49 @@ public class ReplayDataParser {
   }
 
   @VisibleForTesting
-  static String readString(LittleEndianDataInputStream dataStream) throws IOException {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    byte tempByte;
-    while ((tempByte = dataStream.readByte()) != 0) {
-      out.write(tempByte);
+  static String readString(ByteBuffer buffer) {
+    final int offset = buffer.position();
+    while (buffer.get() != 0) {
     }
-    return out.toString(StandardCharsets.UTF_8);
+    final int length = buffer.position() - 1 - offset;
+    byte[] stringBytes = new byte[length];
+    buffer.get(offset, stringBytes);
+    return new String(stringBytes, StandardCharsets.UTF_8);
   }
 
-  private Object parseLua(LittleEndianDataInputStream dataStream) throws IOException {
-    int type = dataStream.readUnsignedByte();
+  private Object parseLua(ByteBuffer buffer) {
+    int type = LoadUtils.getUnsignedByte(buffer);
     switch (type) {
       case LUA_NUMBER:
-        return dataStream.readFloat();
+        return buffer.getFloat();
       case LUA_STRING:
-        return readString(dataStream);
+        return readString(buffer);
       case LUA_NIL:
-        dataStream.skipBytes(1);
+        buffer.get();
         return null;
       case LUA_BOOL: // bool
-        return dataStream.readUnsignedByte() == 0;
+        return LoadUtils.getUnsignedByte(buffer) == 0;
       case LUA_TABLE_START: // lua
         Map<String, Object> result = new HashMap<>();
-        while (peek(dataStream) != LUA_TABLE_END) {
-          Object key = parseLua(dataStream);
+        while (peek(buffer) != LUA_TABLE_END) {
+          Object key = parseLua(buffer);
           if (key instanceof Number) {
             key = ((Number) key).intValue();
           }
-          result.put(String.valueOf(key), parseLua(dataStream));
-          dataStream.mark(1);
+          result.put(String.valueOf(key), parseLua(buffer));
+          buffer.mark();
         }
-        dataStream.skipBytes(1);
+        buffer.get();
         return result;
       default:
         throw new IllegalStateException("Unexpected data type: " + type);
     }
   }
 
-  private int peek(LittleEndianDataInputStream dataStream) throws IOException {
-    dataStream.mark(1);
-    int next = dataStream.readUnsignedByte();
-    dataStream.reset();
+  private int peek(ByteBuffer buffer) {
+    buffer.mark();
+    int next = LoadUtils.getUnsignedByte(buffer);
+    buffer.reset();
     return next;
   }
 
@@ -164,51 +165,51 @@ public class ReplayDataParser {
   }
 
   @SuppressWarnings("unchecked")
-  private void parseHeader(LittleEndianDataInputStream dataStream) throws IOException {
-    replayPatchFieldId = readString(dataStream);
-    String arg13 = readString(dataStream); // always \r\n
+  private void parseHeader(ByteBuffer buffer) {
+    replayPatchFieldId = readString(buffer);
+    String arg13 = readString(buffer); // always \r\n
 
-    String[] split = readString(dataStream).split("\\r\\n");
+    String[] split = readString(buffer).split("\\r\\n");
     String replayVersionId = split[0];
     map = split[1];
-    String arg23 = readString((dataStream)); // always \r\n and some unknown character
+    String arg23 = readString((buffer)); // always \r\n and some unknown character
 
-    int sizeModsInBytes = dataStream.readInt();
-    mods = (Map<String, Map<String, ?>>) parseLua(dataStream);
+    int sizeModsInBytes = buffer.getInt();
+    mods = (Map<String, Map<String, ?>>) parseLua(buffer);
 
-    int sizeGameOptionsInBytes = dataStream.readInt();
-    this.gameOptions = ((Map<String, Object>) parseLua(dataStream)).entrySet().stream()
+    int sizeGameOptionsInBytes = buffer.getInt();
+    this.gameOptions = ((Map<String, Object>) parseLua(buffer)).entrySet().stream()
       .filter(entry -> "Options".equals(entry.getKey()))
       .flatMap(entry -> ((Map<String, Object>) entry.getValue()).entrySet().stream())
       .map(entry -> new GameOption(entry.getKey(), entry.getValue()))
       .collect(Collectors.toList());
 
-    int numberOfSources = dataStream.readUnsignedByte();
+    int numberOfSources = LoadUtils.getUnsignedByte(buffer);
 
-    Map<String, Object> playerIdsByName = new HashMap<>();
+    playerIdsByName = new HashMap<>();
     for (int i = 0; i < numberOfSources; i++) {
-      String playerName = readString(dataStream);
-      int playerId = dataStream.readInt();
+      String playerName = readString(buffer);
+      int playerId = buffer.getInt();
       playerIdsByName.put(playerName, playerId);
     }
 
-    boolean cheatsEnabled = dataStream.readUnsignedByte() > 0;
+    boolean cheatsEnabled = LoadUtils.getUnsignedByte(buffer) > 0;
 
-    int numberOfArmies = dataStream.readUnsignedByte();
+    int numberOfArmies = LoadUtils.getUnsignedByte(buffer);
     for (int i = 0; i < numberOfArmies; i++) {
-      int sizePlayerDataInBytes = dataStream.readInt();
-      Map<String, Object> playerData = (Map<String, Object>) parseLua(dataStream);
-      int playerSource = dataStream.readUnsignedByte();
+      int sizePlayerDataInBytes = buffer.getInt();
+      Map<String, Object> playerData = (Map<String, Object>) parseLua(buffer);
+      int playerSource = LoadUtils.getUnsignedByte(buffer);
 
       armies.put(playerSource, playerData);
       playerData.put("commands", new ArrayList<>());
 
       if (playerSource != 255) {
-        dataStream.skipBytes(1);
+        buffer.get();
       }
     }
 
-    randomSeed = dataStream.readInt();
+    randomSeed = buffer.getInt();
   }
 
   private void interpretEvents(List<Event> events) {
@@ -288,19 +289,13 @@ public class ReplayDataParser {
         case Event.IssueCommand(
           Event.CommandUnits commandUnits, Event.CommandData commandData
         ) -> {
-          commandsPerMinuteByPlayer
-            .computeIfAbsent(player, p -> new HashMap<>())
-            .computeIfAbsent(ticks, t -> new AtomicInteger())
-            .incrementAndGet();
+
         }
 
         case Event.IssueFactoryCommand(
           Event.CommandUnits commandUnits, Event.CommandData commandData
         ) -> {
-          commandsPerMinuteByPlayer
-            .computeIfAbsent(player, p -> new HashMap<>())
-            .computeIfAbsent(ticks, t -> new AtomicInteger())
-            .incrementAndGet();
+
         }
 
         case Event.IncreaseCommandCount(int commandId, int delta) -> {
@@ -364,10 +359,13 @@ public class ReplayDataParser {
   }
 
   private void parseGiveResourcesToPlayer(LuaData.Table lua) {
-    if (lua.value().containsKey("Msg") && lua.value().containsKey("From") && lua.value().containsKey("Sender")) {
+    LuaData msg;
+    LuaData from;
+    LuaData sender;
+    if ((msg = lua.value().get("Msg")) != null && (from = lua.value().get("From")) != null && (sender = lua.value().get("Sender")) != null) {
 
       // TODO: use the command source (player value) instead of the values from the callback. The values from the callback can be manipulated
-      if (!(lua.value().get("From") instanceof LuaData.Number(float luaFromArmy))) {
+      if (!(from instanceof LuaData.Number(float luaFromArmy))) {
         return;
       }
 
@@ -376,11 +374,11 @@ public class ReplayDataParser {
         return;
       }
 
-      if (!(lua.value().get("Msg") instanceof LuaData.Table(Map<String, LuaData> luaMsg))) {
+      if (!(msg instanceof LuaData.Table(Map<String, LuaData> luaMsg))) {
         return;
       }
 
-      if (!(lua.value().get("Sender") instanceof LuaData.String(String luaSender))) {
+      if (!(sender instanceof LuaData.String(String luaSender))) {
         return;
       }
 
@@ -442,12 +440,18 @@ public class ReplayDataParser {
   }
 
   private void parse() throws IOException, CompressorException {
-    readReplayData(path);
-    try (LittleEndianDataInputStream dataStream = new LittleEndianDataInputStream(new ByteArrayInputStream(data))) {
-      parseHeader(dataStream);
-      tokens = ReplayBodyTokenizer.tokenize(dataStream);
-    }
-    events = ReplayBodyParser.parseTokens(tokens);
-    interpretEvents(events);
+      readReplayData(path);
+
+      final ByteBuffer buffer = ByteBuffer.wrap(data);
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+      parseHeader(buffer);
+
+      var rewindPosition = buffer.position();
+      tokens = ReplayBodyTokenizer.tokenize(buffer);
+      buffer.position(rewindPosition);
+
+      events = ReplayBodyParser.parseTokens(tokens, buffer);
+      interpretEvents(events);
   }
 }

--- a/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -359,42 +359,36 @@ public class ReplayDataParser {
   }
 
   private void parseGiveResourcesToPlayer(LuaData.Table lua) {
-    LuaData msg;
-    LuaData from;
-    LuaData sender;
-    if ((msg = lua.value().get("Msg")) != null && (from = lua.value().get("From")) != null && (sender = lua.value().get("Sender")) != null) {
+    // TODO: use the command source (player value) instead of the values from the callback. The values from the callback can be manipulated
+    if (!(lua.value().get("From") instanceof LuaData.Number(float luaFromArmy))) {
+      return;
+    }
 
-      // TODO: use the command source (player value) instead of the values from the callback. The values from the callback can be manipulated
-      if (!(from instanceof LuaData.Number(float luaFromArmy))) {
-        return;
-      }
+    int fromArmy = (int) luaFromArmy - 1;
+    if (fromArmy == -2) {
+      return;
+    }
 
-      int fromArmy = (int) luaFromArmy - 1;
-      if (fromArmy == -2) {
-        return;
-      }
+    if (!(lua.value().get("Msg") instanceof LuaData.Table(Map<String, LuaData> luaMsg))) {
+      return;
+    }
 
-      if (!(msg instanceof LuaData.Table(Map<String, LuaData> luaMsg))) {
-        return;
-      }
+    if (!(lua.value().get("Sender") instanceof LuaData.String(String luaSender))) {
+      return;
+    }
 
-      if (!(sender instanceof LuaData.String(String luaSender))) {
-        return;
-      }
+    // This can either be a player name or a Map of something, in which case it's actually giving resources
+    if (!(luaMsg.get("to") instanceof LuaData.String(String luaMsgReceiver))) {
+      return;
+    }
 
-      // This can either be a player name or a Map of something, in which case it's actually giving resources
-      if (!(luaMsg.get("to") instanceof LuaData.String(String luaMsgReceiver))) {
-        return;
-      }
+    if (!(luaMsg.get("text") instanceof LuaData.String(String luaMsgText))) {
+      return;
+    }
 
-      if (!(luaMsg.get("text") instanceof LuaData.String(String luaMsgText))) {
-        return;
-      }
-
-      Map<String, Object> army = armies.get(fromArmy);
-      if (army != null && Objects.equals(army.get("PlayerName"), luaSender)) {
-        chatMessages.add(new ChatMessage(tickToTime(ticks), luaSender, String.valueOf(luaMsgReceiver), luaMsgText));
-      }
+    Map<String, Object> army = armies.get(fromArmy);
+    if (army != null && Objects.equals(army.get("PlayerName"), luaSender)) {
+      chatMessages.add(new ChatMessage(tickToTime(ticks), luaSender, String.valueOf(luaMsgReceiver), luaMsgText));
     }
   }
 
@@ -440,18 +434,18 @@ public class ReplayDataParser {
   }
 
   private void parse() throws IOException, CompressorException {
-      readReplayData(path);
+    readReplayData(path);
 
-      final ByteBuffer buffer = ByteBuffer.wrap(data);
-      buffer.order(ByteOrder.LITTLE_ENDIAN);
+    final ByteBuffer buffer = ByteBuffer.wrap(data);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
 
-      parseHeader(buffer);
+    parseHeader(buffer);
 
-      var rewindPosition = buffer.position();
-      tokens = ReplayBodyTokenizer.tokenize(buffer);
-      buffer.position(rewindPosition);
+    var rewindPosition = buffer.position();
+    tokens = ReplayBodyTokenizer.tokenize(buffer);
+    buffer.position(rewindPosition);
 
-      events = ReplayBodyParser.parseTokens(tokens, buffer);
-      interpretEvents(events);
+    events = ReplayBodyParser.parseTokens(tokens, buffer);
+    interpretEvents(events);
   }
 }

--- a/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -8,7 +8,6 @@ import com.faforever.commons.replay.shared.LoadUtils;
 import com.faforever.commons.replay.shared.LuaData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.BaseEncoding;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.compressors.CompressorException;
@@ -46,7 +45,7 @@ public class ReplayDataParser {
   @Getter
   private String replayPatchFieldId;
   @Getter
-  private byte[] data;
+  private ByteBuffer data;
   @Getter
   private String map;
   @Getter
@@ -129,13 +128,19 @@ public class ReplayDataParser {
   private void readReplayData(Path replayFile) throws IOException, CompressorException {
     byte[] allReplayData = Files.readAllBytes(replayFile);
     int headerEnd = findReplayHeaderEnd(allReplayData);
-    metadata = objectMapper.readValue(new String(Arrays.copyOf(allReplayData, headerEnd), StandardCharsets.UTF_8), ReplayMetadata.class);
-    data = decompress(Arrays.copyOfRange(allReplayData, headerEnd + 1, allReplayData.length), metadata);
+    ByteBuffer buffer = ByteBuffer.wrap(allReplayData);
+
+    buffer.limit(headerEnd);
+    final String decodedMetadata = StandardCharsets.UTF_8.newDecoder().decode(buffer).toString();
+    metadata = objectMapper.readValue(decodedMetadata, ReplayMetadata.class);
+    buffer.limit(buffer.capacity());
+
+    buffer.position(headerEnd + 1);
+    data = decompress(buffer, metadata);
   }
 
   private int findReplayHeaderEnd(byte[] replayData) {
-    int headerEnd;
-    for (headerEnd = 0; headerEnd < replayData.length; headerEnd++) {
+    for (int headerEnd = 0; headerEnd < replayData.length; headerEnd++) {
       if (replayData[headerEnd] == '\n') {
         return headerEnd;
       }
@@ -143,20 +148,22 @@ public class ReplayDataParser {
     throw new IllegalArgumentException("Missing separator between replay header and body");
   }
 
-  private byte[] decompress(byte[] data, @NotNull ReplayMetadata metadata) throws IOException, CompressorException {
+  private ByteBuffer decompress(ByteBuffer inputBuffer, @NotNull ReplayMetadata metadata) throws IOException, CompressorException {
     CompressionType compressionType = Objects.requireNonNullElse(metadata.getCompression(), CompressionType.QTCOMPRESS);
 
     switch (compressionType) {
       case QTCOMPRESS: {
-        return QtCompress.qUncompress(BaseEncoding.base64().decode(new String(data)));
+        return QtCompress.qUncompress(Base64.getDecoder().decode(inputBuffer));
       }
       case ZSTD: {
-        ByteArrayInputStream arrayInputStream = new ByteArrayInputStream(data);
+        byte[] inputArray = new byte[inputBuffer.remaining()];
+        inputBuffer.get(inputArray);
+        ByteArrayInputStream arrayInputStream = new ByteArrayInputStream(inputArray);
         CompressorInputStream compressorInputStream = new CompressorStreamFactory().createCompressorInputStream(arrayInputStream);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(compressorInputStream, out);
-        return out.toByteArray();
+        return ByteBuffer.wrap(out.toByteArray());
       }
       case UNKNOWN:
       default:
@@ -249,7 +256,7 @@ public class ReplayDataParser {
           previousTick = ticks;
 
           if (desync) {
-            log.warn("Replay desynced");
+//            log.warn("Replay desynced");
             return;
           }
         }
@@ -435,17 +442,15 @@ public class ReplayDataParser {
 
   private void parse() throws IOException, CompressorException {
     readReplayData(path);
+    data.order(ByteOrder.LITTLE_ENDIAN);
 
-    final ByteBuffer buffer = ByteBuffer.wrap(data);
-    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    parseHeader(data);
 
-    parseHeader(buffer);
+    var rewindPosition = data.position();
+    tokens = ReplayBodyTokenizer.tokenize(data);
+    data.position(rewindPosition);
 
-    var rewindPosition = buffer.position();
-    tokens = ReplayBodyTokenizer.tokenize(buffer);
-    buffer.position(rewindPosition);
-
-    events = ReplayBodyParser.parseTokens(tokens, buffer);
+    events = ReplayBodyParser.parseTokens(tokens, data);
     interpretEvents(events);
   }
 }

--- a/data/src/main/java/com/faforever/commons/replay/ReplayLoader.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayLoader.java
@@ -10,7 +10,6 @@ import com.faforever.commons.replay.header.Source;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.LittleEndianDataInputStream;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
@@ -22,6 +21,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,29 +33,33 @@ import java.util.Objects;
 public class ReplayLoader {
 
   @Contract(pure = true)
-  private static ReplayHeader loadSCFAReplayHeader(LittleEndianDataInputStream stream) throws IOException {
-    return ReplayHeaderParser.parse(stream);
+  private static ReplayHeader loadSCFAReplayHeader(ByteBuffer buffer) {
+    return ReplayHeaderParser.parse(buffer);
   }
 
   @Contract(pure = true)
-  private static @NotNull List<RegisteredEvent> loadSCFAReplayBody(List<Source> sources, LittleEndianDataInputStream stream) throws IOException {
-    List<ReplayBodyToken> bodyTokens = ReplayBodyTokenizer.tokenize(stream);
-    List<Event> bodyEvents = ReplayBodyParser.parseTokens(bodyTokens);
+  private static @NotNull List<RegisteredEvent> loadSCFAReplayBody(List<Source> sources, ByteBuffer buffer) {
+    var rewindPosition = buffer.position();
+    List<ReplayBodyToken> bodyTokens = ReplayBodyTokenizer.tokenize(buffer);
+    buffer.position(rewindPosition);
+
+    List<Event> bodyEvents = ReplayBodyParser.parseTokens(bodyTokens, buffer);
     return ReplaySemantics.registerEvents(sources, bodyEvents);
   }
 
   @Contract(pure = true)
   private static ReplayContainer loadSCFAReplayFromMemory(ReplayMetadata metadata, byte[] scfaReplayBytes) throws IOException {
-    try (LittleEndianDataInputStream stream = new LittleEndianDataInputStream((new ByteArrayInputStream(scfaReplayBytes)))) {
-      ReplayHeader replayHeader = loadSCFAReplayHeader(stream);
-      List<RegisteredEvent> replayBody = loadSCFAReplayBody(replayHeader.sources(), stream);
+    final ByteBuffer buffer = ByteBuffer.wrap(scfaReplayBytes);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
 
-      if (stream.available() > 0) {
-        throw new EOFException();
-      }
+    ReplayHeader replayHeader = loadSCFAReplayHeader(buffer);
+    List<RegisteredEvent> replayBody = loadSCFAReplayBody(replayHeader.sources(), buffer);
 
-      return new ReplayContainer(metadata, replayHeader, replayBody);
+    if (buffer.position() != buffer.limit()) {
+      throw new EOFException();
     }
+
+    return new ReplayContainer(metadata, replayHeader, replayBody);
   }
 
   public static ReplayContainer loadSCFAReplayFromDisk(Path scfaReplayFile) throws IOException, IllegalArgumentException {

--- a/data/src/main/java/com/faforever/commons/replay/ReplayLoader.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayLoader.java
@@ -9,11 +9,10 @@ import com.faforever.commons.replay.header.ReplayHeaderParser;
 import com.faforever.commons.replay.header.Source;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.BaseEncoding;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,7 +25,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 
@@ -48,14 +47,13 @@ public class ReplayLoader {
   }
 
   @Contract(pure = true)
-  private static ReplayContainer loadSCFAReplayFromMemory(ReplayMetadata metadata, byte[] scfaReplayBytes) throws IOException {
-    final ByteBuffer buffer = ByteBuffer.wrap(scfaReplayBytes);
-    buffer.order(ByteOrder.LITTLE_ENDIAN);
+  private static ReplayContainer loadSCFAReplayFromMemory(ReplayMetadata metadata, ByteBuffer scfaReplayBuffer) throws IOException {
+    scfaReplayBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
-    ReplayHeader replayHeader = loadSCFAReplayHeader(buffer);
-    List<RegisteredEvent> replayBody = loadSCFAReplayBody(replayHeader.sources(), buffer);
+    ReplayHeader replayHeader = loadSCFAReplayHeader(scfaReplayBuffer);
+    List<RegisteredEvent> replayBody = loadSCFAReplayBody(replayHeader.sources(), scfaReplayBuffer);
 
-    if (buffer.position() != buffer.limit()) {
+    if (scfaReplayBuffer.position() != scfaReplayBuffer.limit()) {
       throw new EOFException();
     }
 
@@ -68,22 +66,25 @@ public class ReplayLoader {
     }
 
     byte[] bytes = Files.readAllBytes(scfaReplayFile);
-    return loadSCFAReplayFromMemory(null, bytes);
+    return loadSCFAReplayFromMemory(null, ByteBuffer.wrap(bytes));
   }
 
   @Contract(pure = true)
   private static ReplayContainer loadFAFReplayFromMemory(byte[] fafReplayBytes) throws IOException, CompressorException {
     int separator = findSeparatorIndex(fafReplayBytes);
-    byte[] metadataBytes = Arrays.copyOfRange(fafReplayBytes, 0, separator);
-    String metadataString = new String(metadataBytes, StandardCharsets.UTF_8);
+    ByteBuffer buffer = ByteBuffer.wrap(fafReplayBytes);
+
+    buffer.limit(separator);
+    final String decodedMetadata = StandardCharsets.UTF_8.newDecoder().decode(buffer).toString();
 
     ObjectMapper parsedMetadata = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    ReplayMetadata replayMetadata = parsedMetadata.readValue(metadataString, ReplayMetadata.class);
+    ReplayMetadata replayMetadata = parsedMetadata.readValue(decodedMetadata, ReplayMetadata.class);
+    buffer.limit(buffer.capacity());
 
-    byte[] compressedReplayBytes = Arrays.copyOfRange(fafReplayBytes, separator + 1, fafReplayBytes.length);
-    byte[] scfaReplayBytes = decompress(compressedReplayBytes, replayMetadata);
+    buffer.position(separator + 1);
+    ByteBuffer scfaReplayBuffer= decompress(buffer, replayMetadata);
 
-    return loadSCFAReplayFromMemory(replayMetadata, scfaReplayBytes);
+    return loadSCFAReplayFromMemory(replayMetadata, scfaReplayBuffer);
   }
 
   public static ReplayContainer loadFAFReplayFromDisk(Path fafReplayFile) throws IOException, CompressorException, IllegalArgumentException {
@@ -96,8 +97,7 @@ public class ReplayLoader {
   }
 
   private static int findSeparatorIndex(byte[] replayData) {
-    int headerEnd;
-    for (headerEnd = 0; headerEnd < replayData.length; headerEnd++) {
+    for (int headerEnd = 0; headerEnd < replayData.length; headerEnd++) {
       if (replayData[headerEnd] == '\n') {
         return headerEnd;
       }
@@ -105,21 +105,22 @@ public class ReplayLoader {
     throw new IllegalArgumentException("Missing separator between replay header and body");
   }
 
-  private static byte[] decompress(byte[] data, @NotNull ReplayMetadata metadata) throws IOException, CompressorException {
+  private static ByteBuffer decompress(ByteBuffer inputBuffer, @NotNull ReplayMetadata metadata) throws IOException, CompressorException {
     CompressionType compressionType = Objects.requireNonNullElse(metadata.getCompression(), CompressionType.QTCOMPRESS);
 
     switch (compressionType) {
       case QTCOMPRESS: {
-        return QtCompress.qUncompress(BaseEncoding.base64().decode(new String(data)));
+        return QtCompress.qUncompress(Base64.getDecoder().decode(inputBuffer));
       }
       case ZSTD: {
-        ByteArrayInputStream arrayInputStream = new ByteArrayInputStream(data);
-        CompressorInputStream compressorInputStream = new CompressorStreamFactory()
-          .createCompressorInputStream(arrayInputStream);
+        byte[] inputArray = new byte[inputBuffer.remaining()];
+        inputBuffer.get(inputArray);
+        ByteArrayInputStream arrayInputStream = new ByteArrayInputStream(inputArray);
+        CompressorInputStream compressorInputStream = new CompressorStreamFactory().createCompressorInputStream(arrayInputStream);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(compressorInputStream, out);
-        return out.toByteArray();
+        return ByteBuffer.wrap(out.toByteArray());
       }
       case UNKNOWN:
       default:

--- a/data/src/main/java/com/faforever/commons/replay/body/ReplayBodyParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/body/ReplayBodyParser.java
@@ -2,11 +2,9 @@ package com.faforever.commons.replay.body;
 
 import com.faforever.commons.replay.shared.LoadUtils;
 import com.faforever.commons.replay.shared.LuaData;
-import com.google.common.io.LittleEndianDataInputStream;
 import org.jetbrains.annotations.Contract;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
@@ -14,10 +12,10 @@ import java.util.List;
 public class ReplayBodyParser {
 
   @Contract(pure = true)
-  public static List<Event> parseTokens(List<ReplayBodyToken> tokens) throws IOException {
+  public static List<Event> parseTokens(List<ReplayBodyToken> tokens, ByteBuffer buffer) {
     return tokens.stream().map((token) -> {
       try {
-        return parseToken(token);
+        return parseToken(token, buffer);
       } catch (Exception exception) {
         return new Event.ProcessingError(token, exception);
       }
@@ -25,49 +23,49 @@ public class ReplayBodyParser {
   }
 
   @Contract(pure = true)
-  private static Event.CommandUnits parseCommandUnits(LittleEndianDataInputStream stream) throws IOException {
-    int unitCount = stream.readInt();
+  private static Event.CommandUnits parseCommandUnits(ByteBuffer stream) {
+    int unitCount = stream.getInt();
     ArrayList<Integer> unitIds = new ArrayList<>(unitCount);
     for (int k = 0; k < unitCount; k++) {
-      unitIds.add(stream.readInt());
+      unitIds.add(stream.getInt());
     }
 
     return new Event.CommandUnits(unitCount, unitIds);
   }
 
   @Contract(pure = true)
-  private static Event.CommandFormation parseCommandFormation(LittleEndianDataInputStream stream) throws IOException {
+  private static Event.CommandFormation parseCommandFormation(ByteBuffer stream) {
     float orientation = 0;
     float px = 0;
     float py = 0;
     float pz = 0;
     float scale = 0;
 
-    int formation = stream.readInt();
+    int formation = stream.getInt();
     if (formation != -1) {
-      orientation = stream.readFloat();
-      px = stream.readFloat();
-      py = stream.readFloat();
-      pz = stream.readFloat();
-      scale = stream.readFloat();
+      orientation = stream.getFloat();
+      px = stream.getFloat();
+      py = stream.getFloat();
+      pz = stream.getFloat();
+      scale = stream.getFloat();
     }
 
     return new Event.CommandFormation(formation, orientation, px, py, pz, scale);
   }
 
   @Contract(pure = true)
-  private static Event.CommandTarget parseCommandTarget(LittleEndianDataInputStream stream) throws IOException {
-    CommandTargetType target = CommandTargetType.values()[stream.readByte()];
+  private static Event.CommandTarget parseCommandTarget(ByteBuffer buffer) {
+    CommandTargetType target = CommandTargetType.values()[buffer.get()];
     switch (target) {
       case ENTITY -> {
-        int entityId = stream.readInt();
+        int entityId = buffer.getInt();
         return new Event.CommandTarget.Entity(entityId);
       }
 
       case POSITION -> {
-        float px = stream.readFloat();
-        float py = stream.readFloat();
-        float pz = stream.readFloat();
+        float px = buffer.getFloat();
+        float py = buffer.getFloat();
+        float pz = buffer.getFloat();
         return new Event.CommandTarget.Position(px, py, pz);
       }
 
@@ -78,23 +76,25 @@ public class ReplayBodyParser {
   }
 
   @Contract(pure = true)
-  private static Event.CommandData parseCommandData(LittleEndianDataInputStream stream) throws IOException {
-    int commandId = stream.readInt();
-    byte[] arg1 = stream.readNBytes(4);
-    EventCommandType commandType = EventCommandType.values()[stream.readByte()];
-    byte[] arg2 = stream.readNBytes(4);
+  private static Event.CommandData parseCommandData(ByteBuffer buffer) {
+    int commandId = buffer.getInt();
+    buffer.position(buffer.position() + 4);
+    EventCommandType commandType = EventCommandType.values()[buffer.get()];
+    buffer.position(buffer.position() + 4);
 
-    Event.CommandTarget commandTarget = parseCommandTarget(stream);
 
-    byte[] arg3 = stream.readNBytes(1);
+    Event.CommandTarget commandTarget = parseCommandTarget(buffer);
 
-    Event.CommandFormation commandFormation = parseCommandFormation(stream);
+    buffer.position(buffer.position() + 1);
 
-    String blueprintId = LoadUtils.readString(stream);
-    byte[] arg4 = stream.readNBytes(12);
 
-    LuaData parametersLua = LoadUtils.parseLua(stream);
-    boolean addToQueue = stream.readByte() > 0;
+    Event.CommandFormation commandFormation = parseCommandFormation(buffer);
+
+    String blueprintId = LoadUtils.readString(buffer);
+    buffer.position(buffer.position() + 12);
+
+    LuaData parametersLua = LoadUtils.parseLua(buffer);
+    boolean addToQueue = buffer.get() > 0;
 
     return new Event.CommandData(
       commandId, commandType, commandTarget, commandFormation, blueprintId, parametersLua, addToQueue
@@ -102,174 +102,180 @@ public class ReplayBodyParser {
   }
 
   @Contract(pure = true)
-  private static Event parseToken(ReplayBodyToken token) throws IOException {
-    try (LittleEndianDataInputStream stream = new LittleEndianDataInputStream((new ByteArrayInputStream(token.tokenContent())))) {
-      Event event = switch (token.tokenId()) {
-        case CMDST_ADVANCE -> {
-          int ticks = stream.readInt();
-          yield new Event.Advance(ticks);
-        }
-
-        case CMDST_SET_COMMAND_SOURCE -> {
-          int playerIndex = stream.readByte();
-          yield new Event.SetCommandSource(playerIndex);
-        }
-
-        case CMDST_COMMAND_SOURCE_TERMINATED -> new Event.CommandSourceTerminated();
-
-        case CMDST_VERIFY_CHECKSUM -> {
-          String hash = HexFormat.of().formatHex(stream.readNBytes(16));
-          int tick = stream.readInt();
-
-          yield new Event.VerifyChecksum(hash, tick);
-        }
-
-        case CMDST_REQUEST_PAUSE -> new Event.RequestPause();
-
-        case CMDST_RESUME -> new Event.RequestResume();
-
-        case CMDST_SINGLE_STEP -> new Event.SingleStep();
-
-        case CMDST_CREATE_UNIT -> {
-          int playerIndex = stream.readByte();
-          String blueprintId = LoadUtils.readString(stream);
-          float px = stream.readFloat();
-          float pz = stream.readFloat();
-          float heading = stream.readFloat();
-
-          yield new Event.CreateUnit(playerIndex, blueprintId, px, pz, heading);
-        }
-
-        case CMDST_CREATE_PROP -> {
-          String blueprintId = LoadUtils.readString(stream);
-          float px = stream.readFloat();
-          float pz = stream.readFloat();
-          float heading = stream.readFloat();
-
-          yield new Event.CreateProp(blueprintId, px, pz, heading);
-        }
-
-        case CMDST_DESTROY_ENTITY -> {
-          int entityId = stream.readInt();
-          yield new Event.DestroyEntity(entityId);
-        }
-
-        case CMDST_WARP_ENTITY -> {
-          int entityId = stream.readInt();
-          float px = stream.readFloat();
-          float py = stream.readFloat();
-          float pz = stream.readFloat();
-          yield new Event.WarpEntity(entityId, px, py, pz);
-        }
-
-        case CMDST_PROCESS_INFO_PAIR -> {
-          int entityId = stream.readInt();
-          String arg1 = LoadUtils.readString(stream);
-          String arg2 = LoadUtils.readString(stream);
-          yield new Event.ProcessInfoPair(entityId, arg1, arg2);
-        }
-
-        case CMDST_ISSUE_COMMAND -> {
-          Event.CommandUnits commandUnits = parseCommandUnits(stream);
-          Event.CommandData commandData = parseCommandData(stream);
-
-          yield new Event.IssueCommand(commandUnits, commandData);
-        }
-
-        case CMDST_ISSUE_FACTORY_COMMAND -> {
-          Event.CommandUnits commandUnits = parseCommandUnits(stream);
-          Event.CommandData commandData = parseCommandData(stream);
-
-          yield new Event.IssueFactoryCommand(commandUnits, commandData);
-        }
-
-        case CMDST_INCREASE_COMMAND_COUNT -> {
-          int commandId = stream.readInt();
-          int delta = stream.readInt();
-          yield new Event.IncreaseCommandCount(commandId, delta);
-        }
-
-        case CMDST_DECRASE_COMMAND_COUNT -> {
-          int commandId = stream.readInt();
-          int delta = stream.readInt();
-          yield new Event.DecreaseCommandCount(commandId, delta);
-        }
-
-        case CMDST_SET_COMMAND_TARGET -> {
-          int commandId = stream.readInt();
-          Event.CommandTarget commandTarget = parseCommandTarget(stream);
-          yield new Event.SetCommandTarget(commandId, commandTarget);
-        }
-
-        case CMDST_SET_COMMAND_TYPE -> {
-          int commandId = stream.readInt();
-          int targetCommandType = stream.readInt();
-          yield new Event.SetCommandType(commandId, targetCommandType);
-        }
-
-        case CMDST_SET_COMMAND_CELLS -> {
-          int commandId = stream.readInt();
-          LuaData parametersLua = LoadUtils.parseLua(stream);
-          if (!(parametersLua instanceof LuaData.Nil)) {
-            stream.readNBytes(1);
-          }
-
-          float px = stream.readFloat();
-          float py = stream.readFloat();
-          float pz = stream.readFloat();
-
-          yield new Event.SetCommandCells(commandId, parametersLua, px, py, pz);
-        }
-
-        case CMDST_REMOVE_COMMAND_FROM_QUEUE -> {
-          int commandId = stream.readInt();
-          int unitId = stream.readInt();
-          yield new Event.RemoveCommandFromQueue(commandId, unitId);
-        }
-
-        case CMDST_DEBUG_COMMAND -> {
-          String command = LoadUtils.readString(stream);
-          float px = stream.readFloat();
-          float py = stream.readFloat();
-          float pz = stream.readFloat();
-          byte focusArmy = stream.readByte();
-          Event.CommandUnits commandUnits = parseCommandUnits(stream);
-
-          yield new Event.DebugCommand(command, px, py, pz, focusArmy, commandUnits);
-        }
-
-        case CMDST_EXECUTE_LUA_IN_SIM -> {
-          String luaCode = LoadUtils.readString(stream);
-          yield new Event.ExecuteLuaInSim(luaCode);
-        }
-
-        case CMDST_LUA_SIM_CALLBACK -> {
-          String func = LoadUtils.readString(stream);
-          LuaData args = LoadUtils.parseLua(stream);
-          Event.CommandUnits commandUnits = null;
-
-          // suspicion that this is just flat out wrong! Whether there's a selection in the data is not related to whether there are Lua arguments
-          if (!(args instanceof LuaData.Nil)) {
-            commandUnits = parseCommandUnits(stream);
-          } else {
-            // the '4' we read here is the size, I suspect the 3 bytes are maybe to align the data somehow? No idea
-            stream.readNBytes(4 + 3);
-          }
-
-          yield new Event.LuaSimCallback(func, args, commandUnits);
-        }
-
-        case CMDST_END_GAME -> new Event.EndGame();
-
-        case null -> new Event.Unprocessed(token, "Unknown");
-      };
-
-      if(stream.available() > 0) {
-        throw new IllegalStateException("Expected end of stream");
+  private static Event parseToken(final ReplayBodyToken token, final ByteBuffer buffer) {
+    // Limit buffer to token end position
+    buffer.limit(token.limit());
+    // Skip header bytes
+    buffer.position(buffer.position() + 3);
+    Event event = switch (token.tokenId()) {
+      case CMDST_ADVANCE -> {
+        int ticks = buffer.getInt();
+        yield new Event.Advance(ticks);
       }
 
-      return event;
+      case CMDST_SET_COMMAND_SOURCE -> {
+        int playerIndex = buffer.get();
+        yield new Event.SetCommandSource(playerIndex);
+      }
+
+      case CMDST_COMMAND_SOURCE_TERMINATED -> new Event.CommandSourceTerminated();
+
+      case CMDST_VERIFY_CHECKSUM -> {
+        final byte[] hashBytes = new byte[16];
+        buffer.get(hashBytes);
+        String hash = HexFormat.of().formatHex(hashBytes);
+        int tick = buffer.getInt();
+
+        yield new Event.VerifyChecksum(hash, tick);
+      }
+
+      case CMDST_REQUEST_PAUSE -> new Event.RequestPause();
+
+      case CMDST_RESUME -> new Event.RequestResume();
+
+      case CMDST_SINGLE_STEP -> new Event.SingleStep();
+
+      case CMDST_CREATE_UNIT -> {
+        int playerIndex = buffer.get();
+        String blueprintId = LoadUtils.readString(buffer);
+        float px = buffer.getFloat();
+        float pz = buffer.getFloat();
+        float heading = buffer.getFloat();
+
+        yield new Event.CreateUnit(playerIndex, blueprintId, px, pz, heading);
+      }
+
+      case CMDST_CREATE_PROP -> {
+        String blueprintId = LoadUtils.readString(buffer);
+        float px = buffer.getFloat();
+        float pz = buffer.getFloat();
+        float heading = buffer.getFloat();
+
+        yield new Event.CreateProp(blueprintId, px, pz, heading);
+      }
+
+      case CMDST_DESTROY_ENTITY -> {
+        int entityId = buffer.getInt();
+        yield new Event.DestroyEntity(entityId);
+      }
+
+      case CMDST_WARP_ENTITY -> {
+        int entityId = buffer.getInt();
+        float px = buffer.getFloat();
+        float py = buffer.getFloat();
+        float pz = buffer.getFloat();
+        yield new Event.WarpEntity(entityId, px, py, pz);
+      }
+
+      case CMDST_PROCESS_INFO_PAIR -> {
+        int entityId = buffer.getInt();
+        String arg1 = LoadUtils.readString(buffer);
+        String arg2 = LoadUtils.readString(buffer);
+        yield new Event.ProcessInfoPair(entityId, arg1, arg2);
+      }
+
+      case CMDST_ISSUE_COMMAND -> {
+        Event.CommandUnits commandUnits = parseCommandUnits(buffer);
+        Event.CommandData commandData = parseCommandData(buffer);
+
+        yield new Event.IssueCommand(commandUnits, commandData);
+      }
+
+      case CMDST_ISSUE_FACTORY_COMMAND -> {
+        Event.CommandUnits commandUnits = parseCommandUnits(buffer);
+        Event.CommandData commandData = parseCommandData(buffer);
+
+        yield new Event.IssueFactoryCommand(commandUnits, commandData);
+      }
+
+      case CMDST_INCREASE_COMMAND_COUNT -> {
+        int commandId = buffer.getInt();
+        int delta = buffer.getInt();
+        yield new Event.IncreaseCommandCount(commandId, delta);
+      }
+
+      case CMDST_DECRASE_COMMAND_COUNT -> {
+        int commandId = buffer.getInt();
+        int delta = buffer.getInt();
+        yield new Event.DecreaseCommandCount(commandId, delta);
+      }
+
+      case CMDST_SET_COMMAND_TARGET -> {
+        int commandId = buffer.getInt();
+        Event.CommandTarget commandTarget = parseCommandTarget(buffer);
+        yield new Event.SetCommandTarget(commandId, commandTarget);
+      }
+
+      case CMDST_SET_COMMAND_TYPE -> {
+        int commandId = buffer.getInt();
+        int targetCommandType = buffer.getInt();
+        yield new Event.SetCommandType(commandId, targetCommandType);
+      }
+
+      case CMDST_SET_COMMAND_CELLS -> {
+        int commandId = buffer.getInt();
+        LuaData parametersLua = LoadUtils.parseLua(buffer);
+        if (!(parametersLua instanceof LuaData.Nil)) {
+          buffer.get();
+        }
+
+        float px = buffer.getFloat();
+        float py = buffer.getFloat();
+        float pz = buffer.getFloat();
+
+        yield new Event.SetCommandCells(commandId, parametersLua, px, py, pz);
+      }
+
+      case CMDST_REMOVE_COMMAND_FROM_QUEUE -> {
+        int commandId = buffer.getInt();
+        int unitId = buffer.getInt();
+        yield new Event.RemoveCommandFromQueue(commandId, unitId);
+      }
+
+      case CMDST_DEBUG_COMMAND -> {
+        String command = LoadUtils.readString(buffer);
+        float px = buffer.getFloat();
+        float py = buffer.getFloat();
+        float pz = buffer.getFloat();
+        byte focusArmy = buffer.get();
+        Event.CommandUnits commandUnits = parseCommandUnits(buffer);
+
+        yield new Event.DebugCommand(command, px, py, pz, focusArmy, commandUnits);
+      }
+
+      case CMDST_EXECUTE_LUA_IN_SIM -> {
+        String luaCode = LoadUtils.readString(buffer);
+        yield new Event.ExecuteLuaInSim(luaCode);
+      }
+
+      case CMDST_LUA_SIM_CALLBACK -> {
+        String func = LoadUtils.readString(buffer);
+        LuaData args = LoadUtils.parseLua(buffer);
+        Event.CommandUnits commandUnits = null;
+
+        // suspicion that this is just flat out wrong! Whether there's a selection in the data is not related to whether there are Lua arguments
+        if (!(args instanceof LuaData.Nil)) {
+          commandUnits = parseCommandUnits(buffer);
+        } else {
+          // the '4' we read here is the size, I suspect the 3 bytes are maybe to align the data somehow? No idea
+          buffer.position(buffer.position() + 4 + 3);
+        }
+
+        yield new Event.LuaSimCallback(func, args, commandUnits);
+      }
+
+      case CMDST_END_GAME -> new Event.EndGame();
+
+      case null -> new Event.Unprocessed(token, "Unknown");
+    };
+
+    // If we are still not at the supposed end of the token calculated from the header, set position to the limit.
+    if (buffer.position() != token.limit()) {
+      buffer.position(token.limit());
+      throw new IllegalStateException("Expected end of token");
     }
+
+    return event;
   }
 
   private enum CommandTargetType {

--- a/data/src/main/java/com/faforever/commons/replay/body/ReplayBodyToken.java
+++ b/data/src/main/java/com/faforever/commons/replay/body/ReplayBodyToken.java
@@ -1,6 +1,6 @@
 package com.faforever.commons.replay.body;
 
-public record ReplayBodyToken(TokenId tokenId, int tokenSize, byte[] tokenContent) {
+public record ReplayBodyToken(TokenId tokenId, int limit) {
 
   public enum TokenId {
     // Order is crucial

--- a/data/src/main/java/com/faforever/commons/replay/body/ReplayBodyTokenizer.java
+++ b/data/src/main/java/com/faforever/commons/replay/body/ReplayBodyTokenizer.java
@@ -1,11 +1,10 @@
 package com.faforever.commons.replay.body;
 
-import com.google.common.io.LittleEndianDataInputStream;
+import com.faforever.commons.replay.shared.LoadUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,15 +14,15 @@ public class ReplayBodyTokenizer {
   private static final int TOKEN_HEADER_LENGTH = 3;
 
   @Contract(pure = true)
-  public static List<ReplayBodyToken> tokenize(@NotNull LittleEndianDataInputStream dataStream) throws IOException {
+  public static List<ReplayBodyToken> tokenize(ByteBuffer buffer) {
     ArrayList<ReplayBodyToken> tokens = new ArrayList<>();
-    while (dataStream.available() > 0) {
-      int tokenId = dataStream.readUnsignedByte();
-      int tokenLength = dataStream.readUnsignedShort();
+    final int length = buffer.limit();
+    while (buffer.position() < length) {
+      final int tokenId = LoadUtils.getUnsignedByte(buffer);
+      final int tokenLength = buffer.getShort() - TOKEN_HEADER_LENGTH;
 
-      byte[] tokenContent = dataStream.readNBytes(tokenLength - TOKEN_HEADER_LENGTH);
-
-      tokens.add(new ReplayBodyToken(ReplayBodyToken.TokenId.values()[tokenId], tokenLength, tokenContent));
+      buffer.position(buffer.position() + tokenLength);
+      tokens.add(new ReplayBodyToken(ReplayBodyToken.TokenId.values()[tokenId], buffer.position()));
     }
 
     return tokens;

--- a/data/src/main/java/com/faforever/commons/replay/header/ReplayHeaderParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/header/ReplayHeaderParser.java
@@ -2,12 +2,10 @@ package com.faforever.commons.replay.header;
 
 import com.faforever.commons.replay.shared.LoadUtils;
 import com.faforever.commons.replay.shared.LuaData;
-import com.google.common.io.LittleEndianDataInputStream;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,188 +15,186 @@ import static com.faforever.commons.replay.shared.LoadUtils.parseLua;
 public class ReplayHeaderParser {
 
   @Contract(pure = true)
-  public static ReplayHeader parse(LittleEndianDataInputStream dataStream) throws IOException {
+  public static ReplayHeader parse(ByteBuffer buffer) {
 
-    String gameVersion = LoadUtils.readString(dataStream);
-    String arg1 = LoadUtils.readString(dataStream); // Always \r\n
+    String gameVersion = LoadUtils.readString(buffer);
+    String arg1 = LoadUtils.readString(buffer); // Always \r\n
 
-    String[] replayAndScenario = LoadUtils.readString(dataStream).split("\\r\\n");
+    String[] replayAndScenario = LoadUtils.readString(buffer).split("\\r\\n");
     String replayVersion = replayAndScenario[0];
     String pathToScenario = replayAndScenario[1];
-    String arg2 = LoadUtils.readString(dataStream); // always \r\n and some unknown character
+    String arg2 = LoadUtils.readString(buffer); // always \r\n and some unknown character
 
-    int sizeModsInBytes = dataStream.readInt();
-    byte[] modBytes = dataStream.readNBytes(sizeModsInBytes);
-    List<GameMod> mods = parseMod(modBytes);
+    int sizeModsInBytes = buffer.getInt();
+    buffer.limit(buffer.position() + sizeModsInBytes);
+    List<GameMod> mods = parseMod(buffer);
+    buffer.limit(buffer.capacity());
 
-    int sizeGameOptionsInBytes = dataStream.readInt();
-    byte[] gameOptionBytes = dataStream.readNBytes(sizeGameOptionsInBytes);
-    GameScenario gameScenario = parseGameScenario((gameOptionBytes));
+    int sizeGameOptionsInBytes = buffer.getInt();
+    buffer.limit(buffer.position() + sizeGameOptionsInBytes);
+    GameScenario gameScenario = parseGameScenario(buffer);
+    buffer.limit(buffer.capacity());
 
-    int numberOfClients = dataStream.readUnsignedByte();
+    int numberOfClients = LoadUtils.getUnsignedByte(buffer);
     List<Source> sources = new ArrayList<>(numberOfClients);
     for (int i = 0; i < numberOfClients; i++) {
-      String playerName = LoadUtils.readString(dataStream);
-      int playerId = dataStream.readInt();
+      String playerName = LoadUtils.readString(buffer);
+      int playerId = buffer.getInt();
       Source source = new Source(i, playerId, playerName);
       sources.add(source);
     }
 
-    boolean cheatsEnabled = dataStream.readUnsignedByte() > 0;
+    boolean cheatsEnabled = LoadUtils.getUnsignedByte(buffer) > 0;
 
-    int numberOfArmies = dataStream.readUnsignedByte();
+    int numberOfArmies = LoadUtils.getUnsignedByte(buffer);
     List<PlayerOptions> allPlayerOptions = new ArrayList<>(numberOfClients);
     for (int i = 0; i < numberOfArmies; i++) {
-      int sizePlayerOptionsInBytes = dataStream.readInt();
-      byte[] playerOptionsBytes = dataStream.readNBytes(sizePlayerOptionsInBytes );
-      PlayerOptions playerOptions = parsePlayerOptions(playerOptionsBytes);
 
-      int playerSource = dataStream.readUnsignedByte();
+      int sizePlayerOptionsInBytes = buffer.getInt();
+      buffer.limit(buffer.position() + sizePlayerOptionsInBytes);
+      PlayerOptions playerOptions = parsePlayerOptions(buffer);
+      buffer.limit(buffer.capacity());
+
+      int playerSource = LoadUtils.getUnsignedByte(buffer);
       allPlayerOptions.add(playerOptions);
 
       if (playerSource != 255) {
-        byte[] arg3 = dataStream.readNBytes(1); // always -1
+        byte arg3 = buffer.get(); // always -1
       }
     }
 
-    int seed = dataStream.readInt();
+    int seed = buffer.getInt();
 
     return new ReplayHeader(gameVersion, replayVersion, pathToScenario, cheatsEnabled, seed, sources, mods, gameScenario, allPlayerOptions);
   }
 
   @Contract(pure = true)
-  private static @Nullable List<GameMod> parseMod(byte[] bytes) throws IOException {
-    try (LittleEndianDataInputStream stream = new LittleEndianDataInputStream((new ByteArrayInputStream(bytes)))) {
-      LuaData modInfo = parseLua(stream);
+  private static @Nullable List<GameMod> parseMod(ByteBuffer buffer) {
+    LuaData modInfo = parseLua(buffer);
 
-      if (modInfo instanceof LuaData.Table table) {
-        return table.value().values().stream().map(
-          e -> {
-            if (e instanceof LuaData.Table luaModInfo) {
-              return new GameMod(
-                luaModInfo.getString("location"),
-                luaModInfo.getString("icon"),
-                luaModInfo.getString("copyright"),
-                luaModInfo.getString("name"),
-                luaModInfo.getString("description"),
-                luaModInfo.getString("author"),
-                luaModInfo.getString("uid"),
-                luaModInfo.getInteger("version"),
-                luaModInfo.getString("url")
-              );
-            }
-
-            return null;
+    if (modInfo instanceof LuaData.Table table) {
+      return table.value().values().stream().map(
+        e -> {
+          if (e instanceof LuaData.Table luaModInfo) {
+            return new GameMod(
+              luaModInfo.getString("location"),
+              luaModInfo.getString("icon"),
+              luaModInfo.getString("copyright"),
+              luaModInfo.getString("name"),
+              luaModInfo.getString("description"),
+              luaModInfo.getString("author"),
+              luaModInfo.getString("uid"),
+              luaModInfo.getInteger("version"),
+              luaModInfo.getString("url")
+            );
           }
-        ).toList();
-      }
 
-      return null;
+          return null;
+        }
+      ).toList();
     }
+
+    return null;
   }
 
   @Contract(pure = true)
-  private static @Nullable GameScenario parseGameScenario(byte[] bytes) throws IOException {
-    try (LittleEndianDataInputStream stream = new LittleEndianDataInputStream((new ByteArrayInputStream(bytes)))) {
-      LuaData gameScenario = parseLua(stream);
+  private static @Nullable GameScenario parseGameScenario(ByteBuffer buffer) {
+    LuaData gameScenario = parseLua(buffer);
 
-      if (gameScenario instanceof LuaData.Table table) {
+    if (gameScenario instanceof LuaData.Table table) {
 
-        // retrieve and manage the game options
-        String scenarioFile = null;
-        GameOptions gameOptions = null;
-        Map<String, String> modOptions = null;
-        if (table.value().get("Options") instanceof LuaData.Table optionsTable) {
+      // retrieve and manage the game options
+      String scenarioFile = null;
+      GameOptions gameOptions = null;
+      Map<String, String> modOptions = null;
+      if (table.value().get("Options") instanceof LuaData.Table optionsTable) {
 
-          scenarioFile = optionsTable.getString("ScenarioFile");
-          gameOptions = new GameOptions(
-            GameOptions.AutoTeams.findByKey(optionsTable.getString("AutoTeams")),
-            GameOptions.TeamLock.findByKey(optionsTable.getString("TeamLock")),
-            GameOptions.TeamSpawn.findByKey(optionsTable.getString("TeamSpawn")),
-            optionsTable.getBool("AllowObservers"),
-            optionsTable.getBool("CheatsEnabled"),
-            optionsTable.getBool("PrebuiltUnits"),
-            optionsTable.getBool("RevealCivilians"),
-            optionsTable.getBool("Score"),
-            optionsTable.getInteger("UnitCap"),
-            optionsTable.getString("Unranked"),
-            GameOptions.Victory.findByKey(optionsTable.getString("Victory"))
-          );
-
-          optionsTable.removeKey("AutoTeams");
-          optionsTable.removeKey("TeamLock");
-          optionsTable.removeKey("TeamSpawn");
-          optionsTable.removeKey("AllowObservers");
-          optionsTable.removeKey("CheatsEnabled");
-          optionsTable.removeKey("PrebuiltUnits");
-          optionsTable.removeKey("RevealCivilians");
-          optionsTable.removeKey("Score");
-          optionsTable.removeKey("UnitCap");
-          optionsTable.removeKey("Unranked");
-          optionsTable.removeKey("Victory");
-
-          modOptions = optionsTable.toKeyStringValuePairs();
-        }
-
-        Integer sizeX = null;
-        Integer sizeZ = null;
-        if (table.getTable("size") instanceof LuaData.Table sizeTable) {
-          sizeX = sizeTable.getInteger("1.0");
-          sizeZ = sizeTable.getInteger("2.0");
-        }
-
-        Integer massReclaimValue = null;
-        Integer energyReclaimValue = null;
-        if (table.value().get("reclaim") instanceof LuaData.Table reclaimTable) {
-          massReclaimValue = reclaimTable.getInteger("1.0");
-          energyReclaimValue = reclaimTable.getInteger("2.0");
-        }
-
-        return new GameScenario(
-          scenarioFile,
-          table.getString("map"),
-          table.getInteger("map_version"),
-          table.getString("description"),
-          table.getString("script"),
-          table.getString("save"),
-          table.getString("name"),
-          sizeX, sizeZ,
-          massReclaimValue, energyReclaimValue,
-          gameOptions, modOptions
+        scenarioFile = optionsTable.getString("ScenarioFile");
+        gameOptions = new GameOptions(
+          GameOptions.AutoTeams.findByKey(optionsTable.getString("AutoTeams")),
+          GameOptions.TeamLock.findByKey(optionsTable.getString("TeamLock")),
+          GameOptions.TeamSpawn.findByKey(optionsTable.getString("TeamSpawn")),
+          optionsTable.getBool("AllowObservers"),
+          optionsTable.getBool("CheatsEnabled"),
+          optionsTable.getBool("PrebuiltUnits"),
+          optionsTable.getBool("RevealCivilians"),
+          optionsTable.getBool("Score"),
+          optionsTable.getInteger("UnitCap"),
+          optionsTable.getString("Unranked"),
+          GameOptions.Victory.findByKey(optionsTable.getString("Victory"))
         );
 
+        optionsTable.removeKey("AutoTeams");
+        optionsTable.removeKey("TeamLock");
+        optionsTable.removeKey("TeamSpawn");
+        optionsTable.removeKey("AllowObservers");
+        optionsTable.removeKey("CheatsEnabled");
+        optionsTable.removeKey("PrebuiltUnits");
+        optionsTable.removeKey("RevealCivilians");
+        optionsTable.removeKey("Score");
+        optionsTable.removeKey("UnitCap");
+        optionsTable.removeKey("Unranked");
+        optionsTable.removeKey("Victory");
+
+        modOptions = optionsTable.toKeyStringValuePairs();
       }
 
-      return null;
+      Integer sizeX = null;
+      Integer sizeZ = null;
+      if (table.getTable("size") instanceof LuaData.Table sizeTable) {
+        sizeX = sizeTable.getInteger("1.0");
+        sizeZ = sizeTable.getInteger("2.0");
+      }
+
+      Integer massReclaimValue = null;
+      Integer energyReclaimValue = null;
+      if (table.value().get("reclaim") instanceof LuaData.Table reclaimTable) {
+        massReclaimValue = reclaimTable.getInteger("1.0");
+        energyReclaimValue = reclaimTable.getInteger("2.0");
+      }
+
+      return new GameScenario(
+        scenarioFile,
+        table.getString("map"),
+        table.getInteger("map_version"),
+        table.getString("description"),
+        table.getString("script"),
+        table.getString("save"),
+        table.getString("name"),
+        sizeX, sizeZ,
+        massReclaimValue, energyReclaimValue,
+        gameOptions, modOptions
+      );
+
     }
+
+    return null;
   }
 
   @Contract(pure = true)
-  private static @Nullable PlayerOptions parsePlayerOptions(byte[] bytes) throws IOException {
-    try (LittleEndianDataInputStream stream = new LittleEndianDataInputStream((new ByteArrayInputStream(bytes)))) {
-      LuaData playerOptions = parseLua(stream);
+  private static @Nullable PlayerOptions parsePlayerOptions(ByteBuffer buffer) {
+    LuaData playerOptions = parseLua(buffer);
 
-      if (playerOptions instanceof LuaData.Table table) {
-        return new PlayerOptions(
-          table.getBool("Human"),
-          table.getString("AIPersonality"),
-          table.getFloat("MEAN"),
-          table.getFloat("DEV"),
-          table.getString("PlayerClan"),
-          table.getBool("Civilian"),
-          table.getInteger("StartSpot"),
-          table.getString("ArmyName"),
-          table.getInteger("ArmyColor"),
-          table.getInteger("PlayerColor"),
-          table.getString("PlayerName"),
-          table.getInteger("NG"),
-          table.getString("Country"),
-          table.getInteger("Team"),
-          table.getInteger("Faction")
-        );
-      }
-
-      return null;
+    if (playerOptions instanceof LuaData.Table table) {
+      return new PlayerOptions(
+        table.getBool("Human"),
+        table.getString("AIPersonality"),
+        table.getFloat("MEAN"),
+        table.getFloat("DEV"),
+        table.getString("PlayerClan"),
+        table.getBool("Civilian"),
+        table.getInteger("StartSpot"),
+        table.getString("ArmyName"),
+        table.getInteger("ArmyColor"),
+        table.getInteger("PlayerColor"),
+        table.getString("PlayerName"),
+        table.getInteger("NG"),
+        table.getString("Country"),
+        table.getInteger("Team"),
+        table.getInteger("Faction")
+      );
     }
+
+    return null;
   }
 }

--- a/data/src/main/java/com/faforever/commons/replay/shared/LoadUtils.java
+++ b/data/src/main/java/com/faforever/commons/replay/shared/LoadUtils.java
@@ -1,10 +1,8 @@
 package com.faforever.commons.replay.shared;
 
-import com.google.common.io.LittleEndianDataInputStream;
 import org.jetbrains.annotations.Contract;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -12,38 +10,39 @@ import java.util.Map;
 public class LoadUtils {
 
   @Contract(pure = true)
-  private static int peek(LittleEndianDataInputStream dataStream) throws IOException {
-    dataStream.mark(1);
-    int next = dataStream.readUnsignedByte();
-    dataStream.reset();
+  private static int peek(ByteBuffer buffer) {
+    buffer.mark();
+    int next = getUnsignedByte(buffer);
+    buffer.reset();
     return next;
   }
 
   /**
    * Parses a value from the data stream
-   * @param dataStream
+   *
+   * @param buffer
    * @return
-   * @throws IOException
    */
   @Contract(pure = true)
-  public static String readString(LittleEndianDataInputStream dataStream) throws IOException {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    byte tempByte;
-    while ((tempByte = dataStream.readByte()) != 0) {
-      out.write(tempByte);
+  public static String readString(ByteBuffer buffer){
+    final int offset = buffer.position();
+    while (buffer.get() != 0) {
     }
-    return out.toString(StandardCharsets.UTF_8);
+    final int length = buffer.position() - 1 - offset;
+    byte[] stringBytes = new byte[length];
+    buffer.get(offset, stringBytes, 0, length);
+    return new String(stringBytes, StandardCharsets.UTF_8);
   }
 
   /**
    * Parses a Lua table from the data stream
-   * @param dataStream
+   *
+   * @param buffer
    * @return
-   * @throws IOException
    */
   @Contract(pure = true)
-  public static LuaData parseLua(LittleEndianDataInputStream dataStream) throws IOException {
-    int type = dataStream.readUnsignedByte();
+  public static LuaData parseLua(ByteBuffer buffer) {
+    int type = getUnsignedByte(buffer);
 
     final int LUA_NUMBER = 0;
     final int LUA_STRING = 1;
@@ -54,12 +53,12 @@ public class LoadUtils {
 
     switch (type) {
       case LUA_NUMBER -> {
-        float value = dataStream.readFloat();
+        float value = buffer.getFloat();
         return new LuaData.Number(value);
       }
 
       case LUA_STRING -> {
-        String value = readString(dataStream);
+        String value = readString(buffer);
         return new LuaData.String(value);
       }
 
@@ -68,30 +67,34 @@ public class LoadUtils {
       }
 
       case LUA_BOOL -> {
-        boolean value = dataStream.readUnsignedByte() == 0;
+        boolean value = getUnsignedByte(buffer) == 0;
         return new LuaData.Bool(value);
       }
 
       case LUA_TABLE_START -> {
         Map<String, LuaData> value = new HashMap<>();
-        while (peek(dataStream) != LUA_TABLE_END) {
-          LuaData key = parseLua(dataStream);
+        while (peek(buffer) != LUA_TABLE_END) {
+          LuaData key = parseLua(buffer);
 
           switch (key) {
-            case LuaData.String(String str) -> value.put(str, parseLua(dataStream));
+            case LuaData.String(String str) -> value.put(str, parseLua(buffer));
 
-            case LuaData.Number(float num) -> value.put(String.valueOf(num), parseLua(dataStream));
+            case LuaData.Number(float num) -> value.put(String.valueOf(num), parseLua(buffer));
 
             default -> throw new IllegalStateException("Unexpected data type: " + type);
           }
 
-          dataStream.mark(1);
+          buffer.mark();
         }
-        dataStream.skipBytes(1);
+        buffer.get();
 
         return new LuaData.Table(value);
       }
       default -> throw new IllegalStateException("Unexpected data type: " + type);
     }
+  }
+
+  public static int getUnsignedByte(ByteBuffer buffer) {
+    return buffer.get() & 0xFF;
   }
 }

--- a/data/src/test/java/com/faforever/commons/replay/QtCompressTest.java
+++ b/data/src/test/java/com/faforever/commons/replay/QtCompressTest.java
@@ -2,6 +2,7 @@ package com.faforever.commons.replay;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import static com.faforever.commons.test.IsUtilityClassMatcher.isUtilityClass;
@@ -30,8 +31,8 @@ class QtCompressTest {
   }
 
   @Test
-  void testQUncompress() throws Exception {
-    byte[] uncompressedBytes = QtCompress.qUncompress(COMPRESSED_BYTES);
-    assertArrayEquals(UNCOMPRESSED_BYTES, uncompressedBytes);
+  void testQUncompress() {
+    ByteBuffer uncompressedByteBuffer = QtCompress.qUncompress(ByteBuffer.wrap(COMPRESSED_BYTES));
+    assertArrayEquals(UNCOMPRESSED_BYTES, uncompressedByteBuffer.array());
   }
 }

--- a/data/src/test/java/com/faforever/commons/replay/ReplayLoaderTableParserTest.java
+++ b/data/src/test/java/com/faforever/commons/replay/ReplayLoaderTableParserTest.java
@@ -18,7 +18,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -109,7 +108,7 @@ class ReplayLoaderTableParserTest {
     Files.copy(getClass().getResourceAsStream("/replay/zstd_reference.fafreplay"), replayFile);
     Files.copy(getClass().getResourceAsStream("/replay/zstd_reference.raw"), referenceFile);
 
-    byte[] data = new ReplayDataParser(replayFile, objectMapper).getData();
+    byte[] data = new ReplayDataParser(replayFile, objectMapper).getData().array();
     byte[] reference = Files.readAllBytes(referenceFile);
     assertThat("Zstd compressed replay matches reference", Arrays.equals(data, reference));
   }
@@ -121,7 +120,7 @@ class ReplayLoaderTableParserTest {
     Files.copy(getClass().getResourceAsStream("/replay/test.fafreplay"), replayFile);
     Files.copy(getClass().getResourceAsStream("/replay/test.raw"), referenceFile);
 
-    byte[] data = new ReplayDataParser(replayFile, objectMapper).getData();
+    byte[] data = new ReplayDataParser(replayFile, objectMapper).getData().array();
     byte[] reference = Files.readAllBytes(referenceFile);
     assertThat("Legacy compressed file matches reference", Arrays.equals(data, reference));
   }

--- a/data/src/test/java/com/faforever/commons/replay/ReplayLoaderTableParserTest.java
+++ b/data/src/test/java/com/faforever/commons/replay/ReplayLoaderTableParserTest.java
@@ -3,14 +3,14 @@ package com.faforever.commons.replay;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.LittleEndianDataInputStream;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,6 +22,7 @@ import java.util.Objects;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 class ReplayLoaderTableParserTest {
 
@@ -59,14 +60,13 @@ class ReplayLoaderTableParserTest {
   }
 
   @Test
-  void testReadString() throws Exception {
+  void testReadString() {
     String unicodeString = "Oh, helloäöüthere!";
 
     byte[] stringBytes = (unicodeString + "\0").getBytes(StandardCharsets.UTF_8);
-    ByteArrayInputStream byteInputStream = new ByteArrayInputStream(stringBytes);
-    LittleEndianDataInputStream dataInputStream = new LittleEndianDataInputStream(byteInputStream);
-
-    String result = ReplayDataParser.readString(dataInputStream);
+    ByteBuffer buffer = ByteBuffer.wrap(stringBytes);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    String result = ReplayDataParser.readString(buffer);
 
     assertThat(result, is(unicodeString));
   }
@@ -137,5 +137,5 @@ class ReplayLoaderTableParserTest {
     ModeratorEvent firstEvent = moderatorEvents.getFirst();
     assertEquals(Duration.ofSeconds(20), firstEvent.time());
     assertEquals("Created a marker with the text: 'my fabelous marker test'", firstEvent.message());
-    }
+  }
 }


### PR DESCRIPTION
Fixes #250
Affects https://github.com/FAForever/downlords-faf-client/issues/3270 and PR https://github.com/FAForever/downlords-faf-client/pull/3394
### Description

Switched parser logic to ByteBuffer from LittleEndianDataInputStream for more direct and performant access to the originally read replay bytes and easier reusability during parsing

Eliminated double reading of stream and multiple smaller tokenContent stream creation for tokenization and parsing by not preparing separate tokenContent byte chucks and reusing the originally created ByteBuffer

Replaced tokenContent and tokenSize with token limit, which stores the read position limit in the ByteBuffer for the corresponding token

Added buffer limiting to parsing to preserve robustness coming from tokenization

Improved performance of readString methods by replacing the ByteArrayOutputStream and double accessing the ByteBuffer for string ending search and extracting string bytes

Implemented getUnsignedByte util for ByteBuffer

Removed unused `commandsPerMinuteByPlayer` event interpret calculation.

### Measurements
I measured the performance of the parser with the help of VisualVM and the ReplayLoaderTableParserTest test class. CPU: AMD Ryzen 9 5950x. I parsed all my local replays (822 at the time of measurements) with the following code:
```
    sleep(10000);

    File folder = new File("c:/Users/Devastator/Downloads/replays/");
    File[] listOfFiles = folder.listFiles();

    var count = new AtomicInteger();
    for (final var filePath : listOfFiles) {
      System.out.println(count.incrementAndGet());
      new ReplayDataParser(filePath.toPath(), objectMapper);
    }
```

Except for the last parallel test:
```
    sleep(10000);

    File folder = new File("c:/Users/Devastator/Downloads/replays/");
    File[] listOfFiles = folder.listFiles();

    var count = new AtomicInteger();

    ExecutorService EXEC = Executors.newFixedThreadPool(4);
    List<Callable<ReplayDataParser>> tasks = new ArrayList<Callable<ReplayDataParser>>();

    for (final var filePath : listOfFiles) {
      Callable<ReplayDataParser> c = new Callable<ReplayDataParser>() {
        @Override
        public ReplayDataParser call() throws Exception {
          System.out.println(count.incrementAndGet());
          return new ReplayDataParser(filePath.toPath(), objectMapper);
        }
      };
      tasks.add(c);
    }
    List<Future<ReplayDataParser>> results = EXEC.invokeAll(tasks);
```
The sleep call is necessary for having time to attach the profiler to the process and start sampling.

See attached measurements:
[Common Replay Parser Profiling.zip](https://github.com/user-attachments/files/22199360/Common.Replay.Parser.Profiling.zip)

Baseline
**Original.nps:** com.faforever.commons.replay.ReplayDataParser.<init> ()	32 699 ms

Replaced LittleEndianDataInputStream with ByteBuffer just in the tokenizer and used `System.arraycopy()` to extract `TokenContent` bytes
**ByteBuffer tokenizer.nps:** com.faforever.commons.replay.ReplayDataParser.<init> ()	27 798 ms

Used `ByteBuffer `instead of the `LittleEndianDataInputStream ` everywhere throughout the parsing process.
**ByteBuffer full.nps:** com.faforever.commons.replay.ReplayDataParser.<init> ()	22 499 ms

Reused the initially created `ByteBuffer` everywhere to avoid buffer creation for individual tokens.
**ByteBuffer full final.nps:** com.faforever.commons.replay.ReplayDataParser.<init> ()	17 898 ms

Used this measurement to determine how parallelization of different replay parsing is scaling. By not limiting the number of  used threads I ran into out of memory exceptions due to heap constraints, so I elected to limit them according to my measurements and saw the best performance with a limit of 4. Up to 4 threads there were measurable performance improvements, however more than 4 threads made the parsing actually slower.
**ByteBuffer full final parallel.nps:** com.faforever.commons.replay.ReplayLoaderTableParserTest.ExecuteParallel ()	13 299 ms