### PR TITLE
Don't expose underlying replay data buffer

### DIFF
--- a/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -44,8 +44,7 @@ public class ReplayDataParser {
   private ReplayMetadata metadata;
   @Getter
   private String replayPatchFieldId;
-  @Getter
-  private ByteBuffer data;
+  private ByteBuffer dataBuffer;
   @Getter
   private String map;
   @Getter
@@ -136,7 +135,7 @@ public class ReplayDataParser {
     buffer.limit(buffer.capacity());
 
     buffer.position(headerEnd + 1);
-    data = decompress(buffer, metadata);
+    dataBuffer = decompress(buffer, metadata);
   }
 
   private int findReplayHeaderEnd(byte[] replayData) {
@@ -442,15 +441,20 @@ public class ReplayDataParser {
 
   private void parse() throws IOException, CompressorException {
     readReplayData(path);
-    data.order(ByteOrder.LITTLE_ENDIAN);
+    dataBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
-    parseHeader(data);
+    parseHeader(dataBuffer);
 
-    var rewindPosition = data.position();
-    tokens = ReplayBodyTokenizer.tokenize(data);
-    data.position(rewindPosition);
+    var rewindPosition = dataBuffer.position();
+    tokens = ReplayBodyTokenizer.tokenize(dataBuffer);
+    dataBuffer.position(rewindPosition);
 
-    events = ReplayBodyParser.parseTokens(tokens, data);
+    events = ReplayBodyParser.parseTokens(tokens, dataBuffer);
     interpretEvents(events);
+  }
+
+  public byte[] getRawReplayData() {
+    byte[] backingArray = dataBuffer.array();
+    return Arrays.copyOf(backingArray, backingArray.length);
   }
 }

--- a/data/src/test/java/com/faforever/commons/replay/ReplayLoaderTableParserTest.java
+++ b/data/src/test/java/com/faforever/commons/replay/ReplayLoaderTableParserTest.java
@@ -108,7 +108,7 @@ class ReplayLoaderTableParserTest {
     Files.copy(getClass().getResourceAsStream("/replay/zstd_reference.fafreplay"), replayFile);
     Files.copy(getClass().getResourceAsStream("/replay/zstd_reference.raw"), referenceFile);
 
-    byte[] data = new ReplayDataParser(replayFile, objectMapper).getData().array();
+    byte[] data = new ReplayDataParser(replayFile, objectMapper).getRawReplayData();
     byte[] reference = Files.readAllBytes(referenceFile);
     assertThat("Zstd compressed replay matches reference", Arrays.equals(data, reference));
   }
@@ -120,7 +120,7 @@ class ReplayLoaderTableParserTest {
     Files.copy(getClass().getResourceAsStream("/replay/test.fafreplay"), replayFile);
     Files.copy(getClass().getResourceAsStream("/replay/test.raw"), referenceFile);
 
-    byte[] data = new ReplayDataParser(replayFile, objectMapper).getData().array();
+    byte[] data = new ReplayDataParser(replayFile, objectMapper).getRawReplayData();
     byte[] reference = Files.readAllBytes(referenceFile);
     assertThat("Legacy compressed file matches reference", Arrays.equals(data, reference));
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new public method providing direct access to raw replay data in byte array format

* **Refactor**
  * Enhanced encapsulation of internal replay buffer structures by restricting direct access and providing a dedicated method for data retrieval, improving API clarity and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->