### PR TITLE
Expose localizable notice metadata

### DIFF
--- a/lobby/src/main/kotlin/com/faforever/commons/lobby/ConnectionApi.kt
+++ b/lobby/src/main/kotlin/com/faforever/commons/lobby/ConnectionApi.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.time.OffsetDateTime
 
 /**
  * API to manage connection to the Lobby server
@@ -49,9 +50,15 @@ internal class InvalidResponse : ServerMessage
  * A general message from the server (automated or broadcast from admin) to display to the user.
  * FIXME: Should maybe offer event codes for translations in case of automated responses.
  */
-data class NoticeInfo(
+data class NoticeInfo @JvmOverloads constructor(
   val style: String?,
   val text: String?,
+  @JsonProperty("i18n_key")
+  val i18nKey: String? = null,
+  @JsonProperty("i18n_args")
+  val i18nArgs: List<String> = emptyList(),
+  @JsonProperty("expires_at")
+  val expiresAt: OffsetDateTime? = null,
 ) : ServerMessage
 
 /**
@@ -210,4 +217,3 @@ internal class ClientPingMessage : ClientMessage
  * Holds no data, just checks if the connection is still alive
  */
 internal class ClientPongMessage : ClientMessage
-

--- a/lobby/src/test/kotlin/com/faforever/commons/lobby/ServerMessageTest.kt
+++ b/lobby/src/test/kotlin/com/faforever/commons/lobby/ServerMessageTest.kt
@@ -102,6 +102,33 @@ class ServerMessageTest {
   }
 
   @Test
+  fun deserializeLocalizableNoticeInfo() {
+    val result = objectMapper.readValue<ServerMessage>(
+      """
+      {
+        "command": "notice",
+        "style": "error",
+        "text": "You are banned from FAF until 2026-05-10T22:00:00+00:00. Reason: test",
+        "i18n_key": "login.error.banned",
+        "i18n_args": ["2026-05-10T22:00:00+00:00", "test"],
+        "expires_at": "2026-05-10T22:00:00+00:00"
+      }
+    """.trimIndent()
+    )
+
+    assertEquals(
+      NoticeInfo(
+        "error",
+        "You are banned from FAF until 2026-05-10T22:00:00+00:00. Reason: test",
+        "login.error.banned",
+        listOf("2026-05-10T22:00:00+00:00", "test"),
+        OffsetDateTime.parse("2026-05-10T22:00:00+00:00")
+      ),
+      result
+    )
+  }
+
+  @Test
   fun deserializeGameJoinFailed() {
     val result = objectMapper.readValue<ServerMessage>(
       """


### PR DESCRIPTION
## Summary
- add optional `i18n_key`, `i18n_args`, and `expires_at` fields to `NoticeInfo`
- keep the existing Java-friendly two-argument constructor for current client callers
- cover deserialization of the localizable notice payload used by FAForever/server#1083

## Verification
- `JAVA_HOME=/Users/yoseph/Codexperiment/.deps/jdk21/Contents/Home ./gradlew test` — 75 tests passed
- `JAVA_HOME=/Users/yoseph/Codexperiment/.deps/jdk21/Contents/Home ./gradlew :lobby:test --tests com.faforever.commons.lobby.ServerMessageTest` — 22 tests passed
- `git diff --check`

Related: FAForever/server#1083
