### PR TITLE
Add Player.currentAvatar DTO field, deprecate AvatarAssignment.selected

### DIFF
--- a/api/src/main/java/com/faforever/commons/api/dto/AvatarAssignment.java
+++ b/api/src/main/java/com/faforever/commons/api/dto/AvatarAssignment.java
@@ -14,6 +14,12 @@ import java.time.OffsetDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Type("avatarAssignment")
 public class AvatarAssignment extends AbstractEntity<AvatarAssignment> {
+  /**
+   * @deprecated The selected avatar is now tracked via {@link Player#getCurrentAvatar()}
+   *     (the {@code login.avatar_id} column). Read/update that relationship instead; this flag is
+   *     kept only for backwards compatibility with older clients and will be removed.
+   */
+  @Deprecated(forRemoval = true)
   @ToString.Include
   private Boolean selected;
   private OffsetDateTime expiresAt;

--- a/api/src/main/java/com/faforever/commons/api/dto/Player.java
+++ b/api/src/main/java/com/faforever/commons/api/dto/Player.java
@@ -51,6 +51,9 @@ public class Player extends AbstractEntity<Player> {
   @JsonIgnore
   private List<AvatarAssignment> avatarAssignments;
 
+  @Relationship("currentAvatar")
+  private Avatar currentAvatar;
+
   @JsonBackReference
   @Relationship("reporterOnModerationReports")
   private Set<ModerationReport> reporterOnModerationReports;


### PR DESCRIPTION
## Summary

Mirrors the faf-java-api change (FAForever/faf-java-api#1146) that makes the API the single writer of a player's selected avatar via the `login.avatar_id` column, exposed as the `player.currentAvatar` relationship.

- **`Player`** — adds the `currentAvatar` relationship (`@Relationship("currentAvatar")`, type `Avatar`). Not `@JsonIgnore`'d so clients can PATCH it to change the selected avatar.
- **`AvatarAssignment`** — marks `selected` as `@Deprecated(forRemoval = true)`; the selected avatar is now tracked via `Player.getCurrentAvatar()`.

## Context

Part of migrating FAF's "currently selected avatar" off the legacy `avatars.selected` join-table flag to the `login.avatar_id` FK, with the lobby reacting via RabbitMQ. The downlords-faf-client migration to PATCH `currentAvatar` (instead of the lobby socket command) depends on this commons release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player data now includes a current avatar relationship, making the active avatar available through the API.
* **Bug Fixes**
  * Legacy avatar selection tracking is now marked for deprecation, with guidance to use the updated current avatar relationship instead.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->