### PR TITLE
Fix zstd decompression of replays with trailing bytes

### DIFF
--- a/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayDataParser.java
@@ -7,6 +7,7 @@ import com.faforever.commons.replay.body.ReplayBodyTokenizer;
 import com.faforever.commons.replay.shared.LoadUtils;
 import com.faforever.commons.replay.shared.LuaData;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.luben.zstd.Zstd;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -161,7 +162,17 @@ public class ReplayDataParser {
         CompressorInputStream compressorInputStream = new CompressorStreamFactory().createCompressorInputStream(arrayInputStream);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        IOUtils.copy(compressorInputStream, out);
+        // Some (older) replay files contain stray trailing bytes after the zstd frame, e.g. a
+        // trailing newline. zstd-jni <= 1.5.2 silently ignored them, but newer libzstd treats any
+        // post-frame bytes as the start of a second frame and fails with "Unknown frame descriptor".
+        // When the frame advertises its content size we read exactly that many bytes so the
+        // decompressor never touches the trailing data; otherwise we fall back to reading it fully.
+        long contentSize = Zstd.getFrameContentSize(inputArray);
+        if (contentSize > 0) {
+          IOUtils.copyLarge(compressorInputStream, out, 0, contentSize);
+        } else {
+          IOUtils.copy(compressorInputStream, out);
+        }
         return ByteBuffer.wrap(out.toByteArray());
       }
       case UNKNOWN:

--- a/data/src/main/java/com/faforever/commons/replay/ReplayLoader.java
+++ b/data/src/main/java/com/faforever/commons/replay/ReplayLoader.java
@@ -9,6 +9,7 @@ import com.faforever.commons.replay.header.ReplayHeaderParser;
 import com.faforever.commons.replay.header.Source;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.luben.zstd.Zstd;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
@@ -119,7 +120,17 @@ public class ReplayLoader {
         CompressorInputStream compressorInputStream = new CompressorStreamFactory().createCompressorInputStream(arrayInputStream);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        IOUtils.copy(compressorInputStream, out);
+        // Some (older) replay files contain stray trailing bytes after the zstd frame, e.g. a
+        // trailing newline. zstd-jni <= 1.5.2 silently ignored them, but newer libzstd treats any
+        // post-frame bytes as the start of a second frame and fails with "Unknown frame descriptor".
+        // When the frame advertises its content size we read exactly that many bytes so the
+        // decompressor never touches the trailing data; otherwise we fall back to reading it fully.
+        long contentSize = Zstd.getFrameContentSize(inputArray);
+        if (contentSize > 0) {
+          IOUtils.copyLarge(compressorInputStream, out, 0, contentSize);
+        } else {
+          IOUtils.copy(compressorInputStream, out);
+        }
         return ByteBuffer.wrap(out.toByteArray());
       }
       case UNKNOWN:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ guava = { module = "com.google.guava:guava", version = "33.5.0-jre" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }
 reactor-netty = { module = "io.projectreactor.netty:reactor-netty", version = "1.3.5" }
 luaj-jse = { module = "org.luaj:luaj-jse", version = "3.0.1" }
-zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.2-5" } # >=1.5.4-1 fails
+zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.6-10" }
 commons-compress = { module = "org.apache.commons:commons-compress", version = "1.28.0" }
 jsonapi-converter = { module = "com.github.jasminb:jsonapi-converter", version = "0.15" }
 q-builders = { module = "com.github.rutledgepaulv:q-builders", version = "1.6" }


### PR DESCRIPTION
## Problem

Updating `zstd-jni` past `1.5.2-5` broke replay parsing: `LoadReplayLoaderTest.parseBinary03` (and our production scenario) failed with `com.github.luben.zstd.ZstdIOException: Unknown frame descriptor`. Reported upstream as [luben/zstd-jni#301](https://github.com/luben/zstd-jni/issues/301).

## Root cause

The `zstd_reference.fafreplay` payload (and matching older production files) is a **complete, valid zstd frame followed by one stray trailing byte** (`0x0a`, a newline) that is *not* part of the zstd stream.

- zstd-jni ≤ 1.5.2 silently ignored bytes left over after a finished frame.
- libzstd 1.5.4+ treats any post-frame bytes as the start of a *second* frame, reads the `0x0a`, can't match a frame magic, and throws `Unknown frame descriptor`.

This is a behavior change in upstream **libzstd's streaming decoder** (the zstd-jni Java wrapper is byte-identical across these versions, and one-shot/CLI decoding has *always* rejected trailing data). The `zstd` CLI of every version rejects the same file with `unknown header`.

`setContinuous(true)` does not help — the frame is complete; the failure is parsing the (non-existent) next frame.

## Fix

In the `ZSTD` branch of `decompress(...)`, read exactly the frame's advertised content size so the decompressor stops at the frame boundary and never touches the trailing byte:

```java
long contentSize = Zstd.getFrameContentSize(inputArray);
if (contentSize > 0) {
  IOUtils.copyLarge(compressorInputStream, out, 0, contentSize);
} else {
  IOUtils.copy(compressorInputStream, out);
}
```

The fallback covers frames without a stored content size (e.g. streamed files from the Rust replay writer, which carry no trailing junk).

The same `decompress` method is duplicated in `ReplayLoader` and `ReplayDataParser`; both are fixed to avoid drift.

Bumped `zstd-jni` to `1.5.6-10`.

## Testing

All 51 `:data` module tests pass, including `parseBinary03` (zstd reference replay) which previously failed on every version after 1.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of replay files compressed with Zstandard, including files that contain extra trailing bytes.
  * Decompression now uses the expected frame size when available, helping avoid incomplete or over-read replay data.
  * Updated the bundled Zstandard library to a newer version for better compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->