### PR TITLE
Add relationshipLink to ElideNavigator for JSON:API relationship endpoints

### DIFF
--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
@@ -27,6 +27,7 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
   private final Optional<ElideNavigator<?>> parentNavigator;
   private Optional<String> id = Optional.empty();
   private Optional<String> relationship = Optional.empty();
+  private Optional<String> relationshipLink = Optional.empty();
   private Optional<Condition<?>> filterCondition = Optional.empty();
   private Optional<Integer> pageSize = Optional.empty();
   private Optional<Integer> pageNumber = Optional.empty();
@@ -114,6 +115,13 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
     return new ElideNavigator<>(dtoClass, this);
   }
 
+  @Override
+  public ElideNavigatorOnId<T> relationshipLink(@NotNull String name) {
+    log.trace("relationship link added: {}", name);
+    this.relationshipLink = Optional.of(name);
+    return this;
+  }
+
   /**
    * Add a sorting rule to the navigator
    * Important: You need to give the full qualified route, there is NO referencing of parent relationships.
@@ -189,6 +197,7 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
     String route = parentNavigator.map(ElideNavigator::build).orElse("/data/" + dtoPath) +
                    id.map(i -> "/" + i).orElse("") +
                    relationship.map(r -> "/" + r).orElse("") +
+                   relationshipLink.map(r -> "/relationships/" + r).orElse("") +
                    queryArgs;
     log.trace("Route built: {}", route);
     return route;

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
@@ -115,13 +115,24 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
   }
 
   @Override
-  public ElideNavigatorOnRelationshipLink relationshipLink(@NotNull String name) {
+  public <R extends ElideEntity> ElideNavigatorOnRelationshipLink<R> relationshipLink(@NotNull Class<R> entityClass,
+                                                                                      @NotNull String name) {
     if (!includes.isEmpty()) {
       throw new IllegalStateException("Cannot navigate to a relationship link with includes on parent");
     }
     log.trace("relationship link added: {}", name);
     String route = build() + "/relationships/" + name;
-    return () -> route;
+    return new ElideNavigatorOnRelationshipLink<>() {
+      @Override
+      public String build() {
+        return route;
+      }
+
+      @Override
+      public Class<R> getDtoClass() {
+        return entityClass;
+      }
+    };
   }
 
   /**

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigator.java
@@ -27,7 +27,6 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
   private final Optional<ElideNavigator<?>> parentNavigator;
   private Optional<String> id = Optional.empty();
   private Optional<String> relationship = Optional.empty();
-  private Optional<String> relationshipLink = Optional.empty();
   private Optional<Condition<?>> filterCondition = Optional.empty();
   private Optional<Integer> pageSize = Optional.empty();
   private Optional<Integer> pageNumber = Optional.empty();
@@ -116,10 +115,13 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
   }
 
   @Override
-  public ElideNavigatorOnId<T> relationshipLink(@NotNull String name) {
+  public ElideNavigatorOnRelationshipLink relationshipLink(@NotNull String name) {
+    if (!includes.isEmpty()) {
+      throw new IllegalStateException("Cannot navigate to a relationship link with includes on parent");
+    }
     log.trace("relationship link added: {}", name);
-    this.relationshipLink = Optional.of(name);
-    return this;
+    String route = build() + "/relationships/" + name;
+    return () -> route;
   }
 
   /**
@@ -197,7 +199,6 @@ public class ElideNavigator<T extends ElideEntity> implements ElideNavigatorSele
     String route = parentNavigator.map(ElideNavigator::build).orElse("/data/" + dtoPath) +
                    id.map(i -> "/" + i).orElse("") +
                    relationship.map(r -> "/" + r).orElse("") +
-                   relationshipLink.map(r -> "/relationships/" + r).orElse("") +
                    queryArgs;
     log.trace("Route built: {}", route);
     return route;

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
@@ -6,4 +6,12 @@ public interface ElideNavigatorOnId<T extends ElideEntity> extends ElideEndpoint
 
   <R extends ElideEntity> ElideNavigatorSelector<R> navigateRelationship(Class<R> entityClass, String name);
 
+  /**
+   * Points the navigator at the JSON:API relationship endpoint
+   * ({@code /data/{type}/{id}/relationships/{name}}), used to read or modify the relationship linkage itself
+   * (e.g. PATCH/POST/DELETE to add, replace or remove members). This differs from
+   * {@link #navigateRelationship(Class, String)}, which addresses the related resource(s).
+   */
+  ElideNavigatorOnId<T> relationshipLink(String name);
+
 }

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
@@ -11,7 +11,10 @@ public interface ElideNavigatorOnId<T extends ElideEntity> extends ElideEndpoint
    * ({@code /data/{type}/{id}/relationships/{name}}), used to read or modify the relationship linkage itself
    * (e.g. PATCH/POST/DELETE to add, replace or remove members). This differs from
    * {@link #navigateRelationship(Class, String)}, which addresses the related resource(s).
+   *
+   * <p>This is a terminal operation: the returned navigator only allows {@link
+   * ElideNavigatorOnRelationshipLink#build()}. Includes are not allowed on the parent.
    */
-  ElideNavigatorOnId<T> relationshipLink(String name);
+  ElideNavigatorOnRelationshipLink relationshipLink(String name);
 
 }

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnId.java
@@ -14,7 +14,9 @@ public interface ElideNavigatorOnId<T extends ElideEntity> extends ElideEndpoint
    *
    * <p>This is a terminal operation: the returned navigator only allows {@link
    * ElideNavigatorOnRelationshipLink#build()}. Includes are not allowed on the parent.
+   *
+   * @param entityClass the type of the related resource(s) the linkage points at
    */
-  ElideNavigatorOnRelationshipLink relationshipLink(String name);
+  <R extends ElideEntity> ElideNavigatorOnRelationshipLink<R> relationshipLink(Class<R> entityClass, String name);
 
 }

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnRelationshipLink.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnRelationshipLink.java
@@ -2,10 +2,12 @@ package com.faforever.commons.api.elide;
 
 /**
  * Terminal navigator pointing at a JSON:API relationship endpoint
- * ({@code /data/{type}/{id}/relationships/{name}}). It only exposes {@link #build()} because a relationship
- * link addresses the linkage itself (read or modify via PATCH/POST/DELETE) and cannot be navigated further.
+ * ({@code /data/{type}/{id}/relationships/{name}}). It only exposes {@link #build()} and the related entity
+ * type, because a relationship link addresses the linkage itself (read or modify via PATCH/POST/DELETE) and
+ * cannot be navigated further. {@code T} is the type of the related resource(s) the linkage points at.
  */
-@FunctionalInterface
-public interface ElideNavigatorOnRelationshipLink {
+public interface ElideNavigatorOnRelationshipLink<T extends ElideEntity> {
   String build();
+
+  Class<T> getDtoClass();
 }

--- a/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnRelationshipLink.java
+++ b/api/src/main/java/com/faforever/commons/api/elide/ElideNavigatorOnRelationshipLink.java
@@ -1,0 +1,11 @@
+package com.faforever.commons.api.elide;
+
+/**
+ * Terminal navigator pointing at a JSON:API relationship endpoint
+ * ({@code /data/{type}/{id}/relationships/{name}}). It only exposes {@link #build()} because a relationship
+ * link addresses the linkage itself (read or modify via PATCH/POST/DELETE) and cannot be navigated further.
+ */
+@FunctionalInterface
+public interface ElideNavigatorOnRelationshipLink {
+  String build();
+}

--- a/api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
+++ b/api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
@@ -88,6 +88,24 @@ class ElideNavigatorTest {
   }
 
   @Test
+  void testRelationshipLink() {
+    assertThat(ElideNavigator.of(MapPool.class)
+                             .id("5")
+                             .relationshipLink("mapVersion")
+                             .build(), is("/data/mapPool/5/relationships/mapVersion"));
+  }
+
+  @Test
+  void testRelationshipLinkAfterNavigateRelationship() {
+    assertThat(ElideNavigator.of(MapPool.class)
+                             .id("5")
+                             .navigateRelationship(MapVersion.class, "mapVersion")
+                             .id("1234")
+                             .relationshipLink("map")
+                             .build(), is("/data/mapPool/5/mapVersion/1234/relationships/map"));
+  }
+
+  @Test
   void testGetListPages() {
     assertThat(ElideNavigator.of(MapPoolAssignment.class)
                              .collection()

--- a/api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
+++ b/api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
@@ -89,10 +89,11 @@ class ElideNavigatorTest {
 
   @Test
   void testRelationshipLink() {
-    assertThat(ElideNavigator.of(MapPool.class)
-                             .id("5")
-                             .relationshipLink("mapVersion")
-                             .build(), is("/data/mapPool/5/relationships/mapVersion"));
+    ElideNavigatorOnRelationshipLink<MapVersion> navigator = ElideNavigator.of(MapPool.class)
+                                                                           .id("5")
+                                                                           .relationshipLink(MapVersion.class, "mapVersion");
+    assertThat(navigator.build(), is("/data/mapPool/5/relationships/mapVersion"));
+    assertThat(navigator.getDtoClass(), is(MapVersion.class));
   }
 
   @Test
@@ -101,7 +102,7 @@ class ElideNavigatorTest {
                              .id("5")
                              .navigateRelationship(MapVersion.class, "mapVersion")
                              .id("1234")
-                             .relationshipLink("map")
+                             .relationshipLink(MapVersion.class, "map")
                              .build(), is("/data/mapPool/5/mapVersion/1234/relationships/map"));
   }
 
@@ -110,7 +111,7 @@ class ElideNavigatorTest {
     assertThrows(IllegalStateException.class, () -> ElideNavigator.of(MapPool.class)
                                                                   .id("5")
                                                                   .addInclude("mapVersion")
-                                                                  .relationshipLink("mapVersion"));
+                                                                  .relationshipLink(MapVersion.class, "mapVersion"));
   }
 
   @Test

--- a/api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
+++ b/api/src/test/java/com/faforever/commons/api/elide/ElideNavigatorTest.java
@@ -106,6 +106,14 @@ class ElideNavigatorTest {
   }
 
   @Test
+  void testCannotRelationshipLinkAfterIncludes() {
+    assertThrows(IllegalStateException.class, () -> ElideNavigator.of(MapPool.class)
+                                                                  .id("5")
+                                                                  .addInclude("mapVersion")
+                                                                  .relationshipLink("mapVersion"));
+  }
+
+  @Test
   void testGetListPages() {
     assertThat(ElideNavigator.of(MapPoolAssignment.class)
                              .collection()


### PR DESCRIPTION
## What

Adds `relationshipLink(name)` to `ElideNavigatorOnId`, which builds the JSON:API **relationship-linkage** endpoint:

```
/data/{type}/{id}/relationships/{name}
```

## Why

`navigateRelationship(Class, name)` already exists, but it addresses the **related resource** (`/data/{type}/{id}/{name}`). JSON:API also defines a separate *relationship* endpoint (`.../relationships/{name}`) used to read or modify the linkage itself — e.g. `PATCH` to replace, `POST` to add, `DELETE` to remove members of a relationship.

Without this, callers that need to operate on a relationship link have to hand-build the path string (`"/data/" + type + "/" + id + "/relationships/" + name`), which is exactly what surfaced in a downlords-faf-client review (clearing `player.currentAvatar`).

## Usage

```java
ElideNavigator.of(Player.class).id("5").relationshipLink("currentAvatar").build();
// -> /data/player/5/relationships/currentAvatar
```

It also composes after `navigateRelationship`:

```java
ElideNavigator.of(MapPool.class).id("5")
    .navigateRelationship(MapVersion.class, "mapVersion").id("1234")
    .relationshipLink("map").build();
// -> /data/mapPool/5/mapVersion/1234/relationships/map
```

## Tests

Added `testRelationshipLink` and `testRelationshipLinkAfterNavigateRelationship` to `ElideNavigatorTest` (18 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to generate direct JSON:API relationship-link endpoints from existing navigation paths.
  * Introduced a dedicated “terminal” relationship-link navigator that targets linkage operations for a specified relationship name and related resource type.
* **Bug Fixes**
  * Enforced correct call order by rejecting relationship-link generation when include-based navigation has already been configured.
* **Tests**
  * Added test coverage for correct URL building for both root and nested relationship-link navigation, plus invalid-order behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->